### PR TITLE
Add `Parser::map` method

### DIFF
--- a/examples/evaluate_expression_string.rs
+++ b/examples/evaluate_expression_string.rs
@@ -2,7 +2,9 @@ use expression::{Expression, Operator, evaluate};
 use std::io;
 use yapcol::error::Error;
 use yapcol::input::core::Input;
-use yapcol::{StringParser, attempt, between, chain_left, chain_right, is, many0, option, satisfy};
+use yapcol::{
+	Parser, StringParser, attempt, between, chain_left, chain_right, is, many0, option, satisfy,
+};
 mod expression;
 
 trait StringExpressionParser: StringParser<Expression> {}
@@ -31,8 +33,16 @@ fn parse_number() -> impl StringExpressionParser {
 	}
 }
 
-fn build_operation(op: Operator) -> impl Fn(Expression, Expression) -> Expression {
-	move |o1, o2| Expression::Operation(Box::new(o1), op.clone(), Box::new(o2))
+fn build_operation(op: char) -> impl Fn(Expression, Expression) -> Expression {
+	let operator = match op {
+		'+' => Operator::Addition,
+		'-' => Operator::Subtraction,
+		'*' => Operator::Multiplication,
+		'/' => Operator::Division,
+		'^' => Operator::Exponentiation,
+		_ => panic!("Unexpected operator char: {}", op),
+	};
+	move |o1, o2| Expression::Operation(Box::new(o1), operator.clone(), Box::new(o2))
 }
 
 fn parse_expression() -> impl StringExpressionParser {
@@ -41,15 +51,7 @@ fn parse_expression() -> impl StringExpressionParser {
 			let parse_plus = is('+');
 			let parse_minus = is('-');
 			let parse_attempt_plus = attempt(&parse_plus);
-			let operator = option(&parse_attempt_plus, &parse_minus)(input)?;
-			match operator {
-				'+' => Ok(build_operation(Operator::Addition)),
-				'-' => Ok(build_operation(Operator::Subtraction)),
-				_ => Err(Error::UnexpectedToken(
-					input.source_name(),
-					input.position(),
-				)),
-			}
+			option(&parse_attempt_plus, &parse_minus).map(build_operation)(input)
 		};
 		chain_left(&parse_factor(), &parse_operator)(input)
 	}
@@ -61,15 +63,7 @@ fn parse_factor() -> impl StringExpressionParser {
 			let parse_multiplication = is('*');
 			let parse_division = is('/');
 			let parse_attempt_multiplication = attempt(&parse_multiplication);
-			let operator = option(&parse_attempt_multiplication, &parse_division)(input)?;
-			match operator {
-				'*' => Ok(build_operation(Operator::Multiplication)),
-				'/' => Ok(build_operation(Operator::Division)),
-				_ => Err(Error::UnexpectedToken(
-					input.source_name(),
-					input.position(),
-				)),
-			}
+			option(&parse_attempt_multiplication, &parse_division).map(build_operation)(input)
 		};
 		chain_left(&parse_exponentiation(), &parse_operator)(input)
 	}
@@ -77,13 +71,7 @@ fn parse_factor() -> impl StringExpressionParser {
 
 fn parse_exponentiation() -> impl StringExpressionParser {
 	|input| {
-		let parse_operator = |input: &mut Input<_>| match is('^')(input) {
-			Ok(_) => Ok(build_operation(Operator::Exponentiation)),
-			Err(_) => Err(Error::UnexpectedToken(
-				input.source_name(),
-				input.position(),
-			)),
-		};
+		let parse_operator = is('^').map(build_operation);
 		chain_right(&parse_bottom(), &parse_operator)(input)
 	}
 }

--- a/examples/evaluate_expression_token.rs
+++ b/examples/evaluate_expression_token.rs
@@ -121,13 +121,8 @@ fn parse_factor() -> impl TokenExpressionParser {
 
 fn parse_exponentiation() -> impl TokenExpressionParser {
 	|input| {
-		let parse_operator = |input: &mut Input<SourceToken>| match is(Token::Operator(
-			Operator::Exponentiation,
-		))(input)
-		{
-			Ok(_) => Ok(build_operation(Operator::Exponentiation)),
-			Err(e) => Err(e),
-		};
+		let parse_operator = is(Token::Operator(Operator::Exponentiation))
+			.map(|_| build_operation(Operator::Exponentiation));
 		chain_right(&parse_bottom(), &parse_operator)(input)
 	}
 }

--- a/src/input/core.rs
+++ b/src/input/core.rs
@@ -34,7 +34,7 @@ pub trait InputToken: Clone {
 ///
 /// # Creating an `Input`
 ///
-/// For character-based parsing use [`crate::input::string::StringInput::new_from_chars`].
+/// For character-based parsing use [`Input::new_from_chars`].
 /// For a stream of pre-built tokens that already implement [`InputToken`], use
 /// [`Input::new_from_tokens`].
 ///

--- a/src/input/core.rs
+++ b/src/input/core.rs
@@ -6,10 +6,10 @@ use std::collections::VecDeque;
 
 /// Represents a single token in the input stream.
 ///
-/// Every item produced by an [`InputSource`] must implement this trait. The blanket
-/// implementation means that in practice you only need to implement `InputToken` manually when
-/// building a custom input source; for character-based parsing the built-in
-/// [`crate::input::string::CharToken`] is used automatically.
+/// Every item produced by an input source must implement this trait. The blanket implementation
+/// means that in practice you only need to implement `InputToken` manually when building a custom
+/// input source; for character-based parsing the built-in [`crate::input::string::CharToken`] is
+/// used automatically.
 ///
 /// # Type Parameters
 ///
@@ -29,7 +29,7 @@ pub trait InputToken: Clone {
 
 /// An input stream that parsers read tokens from.
 ///
-/// `Input` wraps any [`InputSource`] and adds buffering, arbitrary lookahead, and position
+/// `Input` wraps any input source and adds buffering, arbitrary lookahead, and position
 /// tracking on top of it. It is the central type that every parser receives as its argument.
 ///
 /// # Creating an `Input`

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -22,13 +22,13 @@
 //!
 //! ## Character-based parsing
 //!
-//! Use [`string::StringInput::new_from_chars`], which wraps a `char` iterator and automatically
+//! Use [`core::Input::new_from_chars`], which wraps a `char` iterator and automatically
 //! tracks source positions:
 //!
 //! ```
-//! use yapcol::input::string::StringInput;
+//! use yapcol::input::core::Input;
 //!
-//! let mut input = StringInput::new_from_chars("hello".chars(), None);
+//! let mut input = Input::new_from_chars("hello".chars(), None);
 //! ```
 //!
 //! ## Token-based parsing

--- a/src/input/string.rs
+++ b/src/input/string.rs
@@ -43,7 +43,7 @@ impl CharToken {
 /// `StringInputSource` wraps a peekable `char` iterator and tracks the current [`Position`]
 /// (line and column) as characters are consumed, producing [`CharToken`]s for each input character.
 ///
-/// This struct is an internal implementation detail; use [`StringInput::new_from_chars`] to
+/// This struct is an internal implementation detail; use [`Input::new_from_chars`] to
 /// create a string-based input.
 struct StringInputSource<I>
 where
@@ -122,8 +122,8 @@ impl<'a> StringInput<'a> {
 	/// # Examples
 	///
 	/// ```
-	/// use yapcol::input::string::StringInput;
-	/// let mut input = StringInput::new_from_chars("hello".chars(), Some(String::from("in.txt")));
+	/// use yapcol::input::core::Input;
+	/// let mut input = Input::new_from_chars("hello".chars(), Some(String::from("in.txt")));
 	/// ```
 	pub fn new_from_chars<S>(chars: S, source_name: Option<String>) -> Input<'a, CharToken>
 	where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,15 +42,13 @@
 //! # Error Handling
 //!
 //! Every parser returns a `Result<O, Error>`. When parsing fails, the `Err` variant contains
-//! one of two possible errors, defined in the [`Error`](Error) enum:
+//! one of two possible errors, defined in the [`Error`] enum:
 //!
-//! - [`Error::UnexpectedToken`](Error::UnexpectedToken)`(Option<String>, Position)`: the
+//! - [`Error::UnexpectedToken`]`(Option<String>, Position)`: the
 //!   parser encountered a token that did not satisfy its requirements. The first field is an
-//!   optional source name (e.g., a file name), and the second is the
-//!   [`Position`](input::position::Position) (line and column) where the unexpected token was
-//!   found.
-//! - [`Error::EndOfInput`](Error::EndOfInput): the input stream was exhausted before the
-//!   parser could match.
+//!   optional source name (e.g., a file name), and the second is the [`input::position::Position`]
+//!   (line and column) where the unexpected token was found.
+//! - [`Error::EndOfInput`]: the input stream was exhausted before the parser could match.
 //!
 //! The code below showcases both error variants in a simple character-based parsing example:
 //!
@@ -71,8 +69,8 @@
 //! assert_eq!(any()(&mut input), Err(Error::EndOfInput));
 //! ```
 //!
-//! The [`Error`](Error) type implements [`Display`](std::fmt::Display), so you can easily
-//! print human-readable error messages:
+//! The [`Error`] type implements [`std::fmt::Display`], so you can easily print human-readable error
+//! messages.
 //!
 //! ```
 //! use yapcol::error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,43 @@ pub trait Parser<IT, O>: Fn(&mut Input<IT>) -> Result<O, Error>
 where
 	IT: InputToken,
 {
+	/// Transforms the output of the current parser using the provided function.
+	///
+	/// # Parameters
+	/// - `self`: The current parser.
+	/// - `f`: A closure or function that maps the previous output of the parser to a new output
+	///   type.
+	///
+	/// # Returns
+	/// A new parser that applies the mapping function `f` to the output of the current parser.
+	///
+	/// # Examples
+	/// ```rust
+	/// use yapcol::{Parser, satisfy, any};
+	/// use yapcol::input::core::{Input};
+	///
+	///
+	/// let is_digit = |c: &char| if c.is_ascii_digit() { Some(*c) } else { None } ;
+	/// let parser = satisfy(is_digit).map(|c| c.to_digit(10));
+	///
+	/// let mut input = Input::new_from_chars("1".chars(), None);
+	/// let result = parser(&mut input);
+	/// assert_eq!(result, Ok(Some(1)));
+	/// ```
+	///
+	/// # Errors
+	/// If the current parser fails, the error is returned as is without invoking the mapping
+	/// function `f`.
+	fn map<F, MO>(self, f: F) -> impl Parser<IT, MO>
+	where
+		F: Fn(O) -> MO,
+		Self: Sized,
+	{
+		move |input| match self(input) {
+			Ok(value) => Ok(f(value)),
+			Err(e) => Err(e),
+		}
+	}
 }
 
 impl<IT, O, X> Parser<IT, O> for X

--- a/src/tests/map.rs
+++ b/src/tests/map.rs
@@ -1,0 +1,46 @@
+use crate::*;
+use input::position::Position;
+
+#[test]
+fn success_simple() {
+	let parser = is('2').map(|c: char| c.to_digit(10));
+	let mut input = Input::new_from_chars("2".chars(), None);
+	assert_eq!(parser(&mut input), Ok(Some(2)));
+	assert!(end_of_input()(&mut input).is_ok()); // Ensure that the input was consumed.
+}
+
+#[test]
+fn success_chained() {
+	let parser = is('2')
+		.map(|c: char| c.to_digit(10))
+		.map(|o| o.unwrap())
+		.map(|x| x * 3);
+	let mut input = Input::new_from_chars("2".chars(), None);
+	assert_eq!(parser(&mut input), Ok(6));
+	assert!(end_of_input()(&mut input).is_ok()); // Ensure that the input was consumed.
+}
+
+#[test]
+fn fail_simple() {
+	let parser = is('2').map(|c: char| c.to_digit(10));
+	let mut input = Input::new_from_chars("3".chars(), None);
+	assert_eq!(
+		parser(&mut input),
+		Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+	);
+	assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+}
+
+#[test]
+fn fail_chained() {
+	let parser = is('5')
+		.map(|c: char| c.to_digit(10))
+		.map(|o| o.unwrap())
+		.map(|x| x * 7);
+	let mut input = Input::new_from_chars("3".chars(), None);
+	assert_eq!(
+		parser(&mut input),
+		Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+	);
+	assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -11,6 +11,7 @@ mod look_ahead;
 mod many0;
 mod many1;
 mod many_until;
+mod map;
 mod maybe;
 mod not_followed_by;
 mod option;


### PR DESCRIPTION
This method allows convenient parser output transformation, where repeated `match` or `?` would be necessary. For example:
```rust
let parser = is('2')
	.map(|c: char| c.to_digit(10))
	.map(|o| o.unwrap())
	.map(|x| x * 3);
```

Closes #10.