### PR TITLE
Add "expected" and "found" to errors

### DIFF
--- a/examples/evaluate_expression_string.rs
+++ b/examples/evaluate_expression_string.rs
@@ -1,8 +1,8 @@
 use expression::{Expression, Operator, evaluate};
 use std::io;
 use yapcol::{
-	Error, Input, Parser, StringParser, attempt, between, chain_left, chain_right, is, many0,
-	option, satisfy,
+	Error, Input, Mismatch, Parser, StringParser, attempt, between, chain_left, chain_right, is,
+	many1, option, satisfy,
 };
 mod expression;
 
@@ -27,7 +27,7 @@ fn parse_number() -> impl StringExpressionParser {
 			Err(_) => Err(Error::UnexpectedToken(
 				input.source_name(),
 				input.position(),
-				None,
+				Some(Mismatch::with_expectation("number", digits)),
 			)),
 		}
 	}
@@ -53,7 +53,7 @@ fn parse_expression() -> impl StringExpressionParser {
 			let parse_attempt_plus = attempt(&parse_plus);
 			option(&parse_attempt_plus, &parse_minus).map(build_operation)(input)
 		};
-		chain_left(&parse_factor(), &parse_operator)(input)
+		chain_left(&parse_factor(), &parse_operator).with_expectation("expression")(input)
 	}
 }
 
@@ -65,14 +65,14 @@ fn parse_factor() -> impl StringExpressionParser {
 			let parse_attempt_multiplication = attempt(&parse_multiplication);
 			option(&parse_attempt_multiplication, &parse_division).map(build_operation)(input)
 		};
-		chain_left(&parse_exponentiation(), &parse_operator)(input)
+		chain_left(&parse_exponentiation(), &parse_operator).with_expectation("factor")(input)
 	}
 }
 
 fn parse_exponentiation() -> impl StringExpressionParser {
 	|input| {
 		let parse_operator = is('^').map(build_operation);
-		chain_right(&parse_bottom(), &parse_operator)(input)
+		chain_right(&parse_bottom(), &parse_operator).with_expectation("exponentiation")(input)
 	}
 }
 

--- a/examples/evaluate_expression_string.rs
+++ b/examples/evaluate_expression_string.rs
@@ -27,6 +27,7 @@ fn parse_number() -> impl StringExpressionParser {
 			Err(_) => Err(Error::UnexpectedToken(
 				input.source_name(),
 				input.position(),
+				None,
 			)),
 		}
 	}

--- a/examples/evaluate_expression_string.rs
+++ b/examples/evaluate_expression_string.rs
@@ -27,7 +27,7 @@ fn parse_number() -> impl StringExpressionParser {
 			Err(_) => Err(Error::UnexpectedToken(
 				input.source_name(),
 				input.position(),
-				Some(Mismatch::with_expectation("number", digits)),
+				Some(Mismatch::new("number", digits)),
 			)),
 		}
 	}

--- a/examples/evaluate_expression_string.rs
+++ b/examples/evaluate_expression_string.rs
@@ -20,7 +20,7 @@ fn parse_digit() -> impl StringParser<char> {
 fn parse_number() -> impl StringExpressionParser {
 	|input| {
 		let parse_digit = parse_digit();
-		let digits = many0(&parse_digit)(input)?;
+		let digits = many1(&parse_digit)(input)?;
 		let digits: String = digits.iter().collect();
 		match digits.parse::<i32>() {
 			Ok(number) => Ok(Expression::Number(number)),

--- a/examples/evaluate_expression_token.rs
+++ b/examples/evaluate_expression_token.rs
@@ -3,8 +3,8 @@ use std::fmt::Display;
 use std::io;
 use yapcol::input::Position;
 use yapcol::{
-	Error, Input, InputToken, Parser, attempt, between, chain_left, chain_right, is, option,
-	satisfy,
+	Error, Input, InputToken, Mismatch, Parser, attempt, between, chain_left, chain_right, is,
+	option, satisfy,
 };
 mod expression;
 
@@ -49,7 +49,7 @@ impl InputToken for SourceToken {
 	}
 }
 
-fn tokenize(input: String) -> Vec<SourceToken> {
+fn tokenize(input: String) -> Result<Vec<SourceToken>, Error> {
 	let mut tokens = Vec::new();
 	let input = input.chars().collect::<Vec<char>>();
 	let mut i = 0;
@@ -72,14 +72,18 @@ fn tokenize(input: String) -> Vec<SourceToken> {
 				let number = number.parse().unwrap();
 				Token::Number(number)
 			}
-			c => panic!("Unexpected character: {c}"),
+			unsupported => {
+				let position = Position::new(1, i + 1);
+				let mismatch = Mismatch::new("valid token", unsupported);
+				return Err(Error::UnexpectedToken(None, position, Some(mismatch)));
+			}
 		};
 		let position = Position::new(1, i);
 		i += 1;
 		tokens.push(SourceToken { token, position });
 	}
 
-	tokens
+	Ok(tokens)
 }
 
 trait TokenExpressionParser: Parser<SourceToken, Expression> {}
@@ -92,7 +96,7 @@ fn parse_number() -> impl TokenExpressionParser {
 		Token::Number(number) => Some(Expression::Number(*number)),
 		_ => None,
 	};
-	satisfy(f)
+	satisfy(f).with_expectation("number")
 }
 
 fn build_operation(op: Operator) -> impl Fn(Expression, Expression) -> Expression {
@@ -110,10 +114,10 @@ fn parse_operations(
 		let operator = option(&parse_attempt_multiplication, &parse_division)(input)?;
 		match operator {
 			Token::Operator(op) => Ok(Box::new(build_operation(op))),
-			_ => Err(Error::UnexpectedToken(
+			t => Err(Error::UnexpectedToken(
 				input.source_name(),
 				input.position(),
-				None,
+				Some(Mismatch::new(Box::new("operator"), Box::new(t))),
 			)),
 		}
 	}
@@ -122,14 +126,14 @@ fn parse_operations(
 fn parse_expression() -> impl TokenExpressionParser {
 	|input| {
 		let parse_operator = parse_operations(Operator::Addition, Operator::Subtraction);
-		chain_left(&parse_factor(), &parse_operator)(input)
+		chain_left(&parse_factor(), &parse_operator).with_expectation("expression")(input)
 	}
 }
 
 fn parse_factor() -> impl TokenExpressionParser {
 	|input| {
 		let parse_operator = parse_operations(Operator::Multiplication, Operator::Division);
-		chain_left(&parse_exponentiation(), &parse_operator)(input)
+		chain_left(&parse_exponentiation(), &parse_operator).with_expectation("factor")(input)
 	}
 }
 
@@ -137,7 +141,7 @@ fn parse_exponentiation() -> impl TokenExpressionParser {
 	|input| {
 		let parse_operator = is(Token::Operator(Operator::Exponentiation))
 			.map(|_| build_operation(Operator::Exponentiation));
-		chain_right(&parse_bottom(), &parse_operator)(input)
+		chain_right(&parse_bottom(), &parse_operator).with_expectation("exponentiation")(input)
 	}
 }
 
@@ -164,11 +168,15 @@ fn main() {
 			Ok(_) if input.len() == 2 && input.starts_with('q') => break,
 			Ok(_) => {
 				input.retain(|c| c != '\n');
-				let tokens = tokenize(input.clone());
-				let mut input = Input::new_from_tokens(tokens, Some("stdin".to_string()));
-				match parse_expression()(&mut input) {
-					Ok(e) => println!("Success: {:?}", evaluate(e)),
-					Err(e) => println!("Failed to parse expression: {e}"),
+				match tokenize(input.clone()) {
+					Ok(tokens) => {
+						let mut input = Input::new_from_tokens(tokens, Some("stdin".to_string()));
+						match parse_expression()(&mut input) {
+							Ok(e) => println!("Success: {:?}", evaluate(e)),
+							Err(e) => println!("Failed to parse expression: {e}"),
+						}
+					}
+					Err(e) => println!("Failed to tokenize: {e}"),
 				}
 			}
 			Err(_) => println!("Failed to read input."),
@@ -193,49 +201,49 @@ mod tokenize_tests {
 	#[test]
 	fn addition() {
 		let input = String::from("+");
-		let tokens = tokenize(input);
+		let tokens = tokenize(input).unwrap();
 		assert_tokens(&tokens, &vec![Token::Operator(Operator::Addition)]);
 	}
 
 	#[test]
 	fn subtraction() {
 		let input = String::from("-");
-		let tokens = tokenize(input);
+		let tokens = tokenize(input).unwrap();
 		assert_tokens(&tokens, &vec![Token::Operator(Operator::Subtraction)]);
 	}
 
 	#[test]
 	fn multiplication() {
 		let input = String::from("*");
-		let tokens = tokenize(input);
+		let tokens = tokenize(input).unwrap();
 		assert_tokens(&tokens, &vec![Token::Operator(Operator::Multiplication)]);
 	}
 
 	#[test]
 	fn division() {
 		let input = String::from("/");
-		let tokens = tokenize(input);
+		let tokens = tokenize(input).unwrap();
 		assert_tokens(&tokens, &vec![Token::Operator(Operator::Division)]);
 	}
 
 	#[test]
 	fn number_single() {
 		let input = String::from("1");
-		let tokens = tokenize(input);
+		let tokens = tokenize(input).unwrap();
 		assert_tokens(&tokens, &vec![Token::Number(1)]);
 	}
 
 	#[test]
 	fn number_multiple() {
 		let input = String::from("167253571");
-		let tokens = tokenize(input);
+		let tokens = tokenize(input).unwrap();
 		assert_tokens(&tokens, &vec![Token::Number(167253571)]);
 	}
 
 	#[test]
 	fn addition_operation() {
 		let input = String::from("15+3");
-		let tokens = tokenize(input);
+		let tokens = tokenize(input).unwrap();
 		assert_tokens(
 			&tokens,
 			&vec![
@@ -253,7 +261,7 @@ mod evaluation_tests {
 	use yapcol::end_of_input;
 
 	fn parse_and_evaluate(input: &str) -> i32 {
-		let tokens = tokenize(String::from(input));
+		let tokens = tokenize(String::from(input)).unwrap();
 		let mut input = Input::new_from_tokens(tokens, None);
 		let output = parse_expression()(&mut input);
 		assert!(end_of_input()(&mut input).is_ok());

--- a/examples/evaluate_expression_token.rs
+++ b/examples/evaluate_expression_token.rs
@@ -74,7 +74,7 @@ fn tokenize(input: String) -> Result<Vec<SourceToken>, Error> {
 			}
 			unsupported => {
 				let position = Position::new(1, i + 1);
-				let mismatch = Mismatch::new("valid token", unsupported);
+				let mismatch = Mismatch::without_expectation(unsupported);
 				return Err(Error::UnexpectedToken(None, position, Some(mismatch)));
 			}
 		};
@@ -117,7 +117,10 @@ fn parse_operations(
 			t => Err(Error::UnexpectedToken(
 				input.source_name(),
 				input.position(),
-				Some(Mismatch::new(Box::new("operator"), Box::new(t))),
+				Some(Mismatch::with_expectation(
+					Box::new("operator"),
+					Box::new(t),
+				)),
 			)),
 		}
 	}

--- a/examples/evaluate_expression_token.rs
+++ b/examples/evaluate_expression_token.rs
@@ -108,10 +108,10 @@ fn parse_operations(
 	operator2: Operator,
 ) -> impl Parser<SourceToken, Box<dyn Fn(Expression, Expression) -> Expression>> {
 	move |input| {
-		let parse_multiplication = is(Token::Operator(operator1.clone()));
-		let parse_division = is(Token::Operator(operator2.clone()));
-		let parse_attempt_multiplication = attempt(&parse_multiplication);
-		let operator = option(&parse_attempt_multiplication, &parse_division)(input)?;
+		let parse_op1 = is(Token::Operator(operator1.clone()));
+		let parse_op2 = is(Token::Operator(operator2.clone()));
+		let parse_attempt_op1 = attempt(&parse_op1);
+		let operator = option(&parse_attempt_op1, &parse_op2)(input)?;
 		match operator {
 			Token::Operator(op) => Ok(Box::new(build_operation(op))),
 			t => Err(Error::UnexpectedToken(

--- a/examples/evaluate_expression_token.rs
+++ b/examples/evaluate_expression_token.rs
@@ -117,10 +117,7 @@ fn parse_operations(
 			t => Err(Error::UnexpectedToken(
 				input.source_name(),
 				input.position(),
-				Some(Mismatch::with_expectation(
-					Box::new("operator"),
-					Box::new(t),
-				)),
+				Some(Mismatch::new(Box::new("operator"), Box::new(t))),
 			)),
 		}
 	}

--- a/examples/evaluate_expression_token.rs
+++ b/examples/evaluate_expression_token.rs
@@ -1,4 +1,5 @@
 use expression::{Expression, Operator, evaluate};
+use std::fmt::Display;
 use std::io;
 use yapcol::input::Position;
 use yapcol::{
@@ -13,6 +14,17 @@ enum Token {
 	Operator(Operator),
 	OpenParenthesis,
 	CloseParenthesis,
+}
+
+impl Display for Token {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Token::Number(n) => write!(f, "{n}"),
+			Token::Operator(op) => write!(f, "{op}"),
+			Token::OpenParenthesis => write!(f, "("),
+			Token::CloseParenthesis => write!(f, ")"),
+		}
+	}
 }
 
 #[derive(Debug, Clone)]

--- a/examples/evaluate_expression_token.rs
+++ b/examples/evaluate_expression_token.rs
@@ -101,6 +101,7 @@ fn parse_operations(
 			_ => Err(Error::UnexpectedToken(
 				input.source_name(),
 				input.position(),
+				None,
 			)),
 		}
 	}

--- a/examples/expression/mod.rs
+++ b/examples/expression/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 #[derive(Debug, PartialEq, Clone)]
 pub enum Operator {
 	Addition,
@@ -5,6 +7,18 @@ pub enum Operator {
 	Multiplication,
 	Division,
 	Exponentiation,
+}
+
+impl Display for Operator {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Operator::Addition => write!(f, "+"),
+			Operator::Subtraction => write!(f, "-"),
+			Operator::Multiplication => write!(f, "*"),
+			Operator::Division => write!(f, "/"),
+			Operator::Exponentiation => write!(f, "^"),
+		}
+	}
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/combinators/any.rs
+++ b/src/combinators/any.rs
@@ -20,7 +20,7 @@ where
 {
 	|input| match input.next_token() {
 		Some(input_token) => Ok(input_token.token_owned()),
-		None => Err(Error::EndOfInput),
+		None => Err(Error::EndOfInput(None)),
 	}
 }
 
@@ -32,7 +32,7 @@ mod tests {
 	fn empty() {
 		let mut input = Input::new_from_chars("".chars(), None);
 		let output = any()(&mut input);
-		assert_eq!(output, Err(Error::EndOfInput));
+		assert_eq!(output, Err(Error::EndOfInput(None)));
 	}
 
 	#[test]

--- a/src/combinators/attempt.rs
+++ b/src/combinators/attempt.rs
@@ -50,7 +50,7 @@ use crate::{InputToken, Parser};
 /// 	Ok((o1, o2))
 /// };
 /// let output = attempt(&consuming_parser)(&mut input);
-/// let mismatch = Mismatch::with_expectation('1', '3');
+/// let mismatch = Mismatch::new('1', '3');
 /// assert_eq!(
 /// 	output,
 /// 	Err(Error::UnexpectedToken(
@@ -128,7 +128,7 @@ mod tests {
 		let mut input = Input::new_from_chars("jello".chars(), None);
 		let parser = is('h');
 		let output = attempt(&parser)(&mut input);
-		let mismatch = Mismatch::with_expectation('h', 'j');
+		let mismatch = Mismatch::new('h', 'j');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(
@@ -150,7 +150,7 @@ mod tests {
 			Ok((o1, o2))
 		};
 		let output = attempt(&consuming_parser)(&mut input);
-		let mismatch = Mismatch::with_expectation('x', 'e');
+		let mismatch = Mismatch::new('x', 'e');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(
@@ -176,7 +176,7 @@ mod tests {
 		assert_eq!(first, Ok('h'));
 		// First attempt consumed 'h'.
 		let second = attempt(&parser)(&mut input);
-		let mismatch = Mismatch::with_expectation('h', 'e');
+		let mismatch = Mismatch::new('h', 'e');
 		assert_eq!(
 			second,
 			Err(Error::UnexpectedToken(
@@ -218,7 +218,7 @@ mod tests {
 		let parser_attempt_1 = attempt(&parser1);
 		let parser = option(&parser_attempt_1, &parser2);
 		let output = attempt(&parser)(&mut input);
-		let mismatch = Mismatch::with_expectation('l', 'h');
+		let mismatch = Mismatch::new('l', 'h');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(
@@ -288,7 +288,7 @@ mod tests {
 		let output = attempt(&parser)(&mut input);
 		// The first parser failed while consuming input and `attempt` was not used, so the input
 		// was consumed, and `option`'s second operand failed.
-		let mismatch = Mismatch::with_expectation('h', 'e');
+		let mismatch = Mismatch::new('h', 'e');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(

--- a/src/combinators/attempt.rs
+++ b/src/combinators/attempt.rs
@@ -28,7 +28,7 @@ use crate::{InputToken, Parser};
 ///
 /// ```
 /// use yapcol::input::Position;
-/// use yapcol::{Error, Input, any, attempt, end_of_input, is};
+/// use yapcol::{Error, Input, Mismatch, any, attempt, end_of_input, is};
 ///
 /// // Succeeds consuming input.
 /// let mut input = Input::new_from_chars("123".chars(), None);
@@ -50,9 +50,14 @@ use crate::{InputToken, Parser};
 /// 	Ok((o1, o2))
 /// };
 /// let output = attempt(&consuming_parser)(&mut input);
+/// let mismatch = Mismatch::new('1', '3');
 /// assert_eq!(
 /// 	output,
-/// 	Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
+/// 	Err(Error::UnexpectedToken(
+/// 		None,
+/// 		Position::new(1, 2),
+/// 		Some(mismatch)
+/// 	))
 /// );
 /// assert_eq!(any()(&mut input), Ok('1')); // Input was not consumed.
 ///
@@ -123,9 +128,14 @@ mod tests {
 		let mut input = Input::new_from_chars("jello".chars(), None);
 		let parser = is('h');
 		let output = attempt(&parser)(&mut input);
+		let mismatch = Mismatch::new('h', 'j');
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 1),
+				Some(mismatch)
+			))
 		);
 		// Input should still be intact.
 		assert_eq!(any()(&mut input), Ok('j'));
@@ -140,9 +150,14 @@ mod tests {
 			Ok((o1, o2))
 		};
 		let output = attempt(&consuming_parser)(&mut input);
+		let mismatch = Mismatch::new('x', 'e');
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 2),
+				Some(mismatch)
+			))
 		);
 		// Input should be rewound even though the inner parser consumed.
 		assert_eq!(any()(&mut input), Ok('h'));
@@ -161,9 +176,14 @@ mod tests {
 		assert_eq!(first, Ok('h'));
 		// First attempt consumed 'h'.
 		let second = attempt(&parser)(&mut input);
+		let mismatch = Mismatch::new('h', 'e');
 		assert_eq!(
 			second,
-			Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 2),
+				Some(mismatch)
+			))
 		);
 		// Input should still have "ello".
 		assert_eq!(any()(&mut input), Ok('e'));
@@ -198,9 +218,14 @@ mod tests {
 		let parser_attempt_1 = attempt(&parser1);
 		let parser = option(&parser_attempt_1, &parser2);
 		let output = attempt(&parser)(&mut input);
+		let mismatch = Mismatch::new('l', 'h');
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 1),
+				Some(mismatch)
+			))
 		);
 		// No input was consumed thanks to `attempt`.
 		assert_eq!(any()(&mut input), Ok('h'));
@@ -263,9 +288,14 @@ mod tests {
 		let output = attempt(&parser)(&mut input);
 		// The first parser failed consuming input and `attempt` was not used, so the input was
 		// consumed, and `option`'s second operand failed.
+		let mismatch = Mismatch::new('h', 'e');
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 2),
+				Some(mismatch)
+			))
 		);
 		assert_eq!(any()(&mut input), Ok('h'));
 		assert_eq!(any()(&mut input), Ok('e'));

--- a/src/combinators/attempt.rs
+++ b/src/combinators/attempt.rs
@@ -88,7 +88,7 @@ mod tests {
 		let mut input = Input::new_from_chars("".chars(), None);
 		let parser = is('h');
 		let output = attempt(&parser)(&mut input);
-		assert_eq!(output, Err(Error::EndOfInput));
+		assert_eq!(output, Err(Error::EndOfInput(Some(Box::new('h')))));
 	}
 
 	#[test]
@@ -96,7 +96,7 @@ mod tests {
 		let mut input = Input::new_from_chars("".chars(), None);
 		let parser = is('h').attempt();
 		let output = parser(&mut input);
-		assert_eq!(output, Err(Error::EndOfInput));
+		assert_eq!(output, Err(Error::EndOfInput(Some(Box::new('h')))));
 	}
 
 	#[test]

--- a/src/combinators/attempt.rs
+++ b/src/combinators/attempt.rs
@@ -50,7 +50,7 @@ use crate::{InputToken, Parser};
 /// 	Ok((o1, o2))
 /// };
 /// let output = attempt(&consuming_parser)(&mut input);
-/// let mismatch = Mismatch::new('1', '3');
+/// let mismatch = Mismatch::with_expectation('1', '3');
 /// assert_eq!(
 /// 	output,
 /// 	Err(Error::UnexpectedToken(
@@ -128,7 +128,7 @@ mod tests {
 		let mut input = Input::new_from_chars("jello".chars(), None);
 		let parser = is('h');
 		let output = attempt(&parser)(&mut input);
-		let mismatch = Mismatch::new('h', 'j');
+		let mismatch = Mismatch::with_expectation('h', 'j');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(
@@ -150,7 +150,7 @@ mod tests {
 			Ok((o1, o2))
 		};
 		let output = attempt(&consuming_parser)(&mut input);
-		let mismatch = Mismatch::new('x', 'e');
+		let mismatch = Mismatch::with_expectation('x', 'e');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(
@@ -176,7 +176,7 @@ mod tests {
 		assert_eq!(first, Ok('h'));
 		// First attempt consumed 'h'.
 		let second = attempt(&parser)(&mut input);
-		let mismatch = Mismatch::new('h', 'e');
+		let mismatch = Mismatch::with_expectation('h', 'e');
 		assert_eq!(
 			second,
 			Err(Error::UnexpectedToken(
@@ -218,7 +218,7 @@ mod tests {
 		let parser_attempt_1 = attempt(&parser1);
 		let parser = option(&parser_attempt_1, &parser2);
 		let output = attempt(&parser)(&mut input);
-		let mismatch = Mismatch::new('l', 'h');
+		let mismatch = Mismatch::with_expectation('l', 'h');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(
@@ -286,9 +286,9 @@ mod tests {
 		// Use `option` while the first does NOT use `attempt`.
 		let parser = option(&parser13, &parser12);
 		let output = attempt(&parser)(&mut input);
-		// The first parser failed consuming input and `attempt` was not used, so the input was
-		// consumed, and `option`'s second operand failed.
-		let mismatch = Mismatch::new('h', 'e');
+		// The first parser failed while consuming input and `attempt` was not used, so the input
+		// was consumed, and `option`'s second operand failed.
+		let mismatch = Mismatch::with_expectation('h', 'e');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(

--- a/src/combinators/attempt.rs
+++ b/src/combinators/attempt.rs
@@ -52,7 +52,7 @@ use crate::{InputToken, Parser};
 /// let output = attempt(&consuming_parser)(&mut input);
 /// assert_eq!(
 /// 	output,
-/// 	Err(Error::UnexpectedToken(None, Position::new(1, 2)))
+/// 	Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
 /// );
 /// assert_eq!(any()(&mut input), Ok('1')); // Input was not consumed.
 ///
@@ -125,7 +125,7 @@ mod tests {
 		let output = attempt(&parser)(&mut input);
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 		);
 		// Input should still be intact.
 		assert_eq!(any()(&mut input), Ok('j'));
@@ -142,7 +142,7 @@ mod tests {
 		let output = attempt(&consuming_parser)(&mut input);
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 2)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
 		);
 		// Input should be rewound even though the inner parser consumed.
 		assert_eq!(any()(&mut input), Ok('h'));
@@ -163,7 +163,7 @@ mod tests {
 		let second = attempt(&parser)(&mut input);
 		assert_eq!(
 			second,
-			Err(Error::UnexpectedToken(None, Position::new(1, 2)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
 		);
 		// Input should still have "ello".
 		assert_eq!(any()(&mut input), Ok('e'));
@@ -200,7 +200,7 @@ mod tests {
 		let output = attempt(&parser)(&mut input);
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 		);
 		// No input was consumed thanks to `attempt`.
 		assert_eq!(any()(&mut input), Ok('h'));
@@ -265,7 +265,7 @@ mod tests {
 		// consumed, and `option`'s second operand failed.
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 2)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
 		);
 		assert_eq!(any()(&mut input), Ok('h'));
 		assert_eq!(any()(&mut input), Ok('e'));

--- a/src/combinators/between.rs
+++ b/src/combinators/between.rs
@@ -43,7 +43,7 @@ mod tests {
 	fn empty() {
 		let mut input = Input::new_from_chars("".chars(), None);
 		let output = between(&is('('), &is('h'), &is(')'))(&mut input);
-		assert_eq!(output, Err(Error::EndOfInput));
+		assert_eq!(output, Err(Error::EndOfInput(Some(Box::new('(')))));
 	}
 
 	#[test]
@@ -51,7 +51,7 @@ mod tests {
 		let mut input = Input::new_from_chars("(x)".chars(), None);
 		let output = between(&is('('), &is('x'), &is(')'))(&mut input);
 		assert_eq!(output, Ok('x'));
-		assert_eq!(any()(&mut input), Err(Error::EndOfInput));
+		assert_eq!(any()(&mut input), Err(Error::EndOfInput(None)));
 	}
 
 	#[test]

--- a/src/combinators/between.rs
+++ b/src/combinators/between.rs
@@ -60,7 +60,7 @@ mod tests {
 		let output = between(&is('('), &is('x'), &is(')'))(&mut input);
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 3)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 3), None))
 		);
 	}
 
@@ -70,7 +70,7 @@ mod tests {
 		let output = between(&is('('), &is('x'), &is(')'))(&mut input);
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 2)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
 		);
 	}
 
@@ -80,7 +80,7 @@ mod tests {
 		let output = between(&is('('), &is('x'), &is(')'))(&mut input);
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 		);
 	}
 }

--- a/src/combinators/between.rs
+++ b/src/combinators/between.rs
@@ -58,7 +58,7 @@ mod tests {
 	fn fail_repeated() {
 		let mut input = Input::new_from_chars("(xx)".chars(), None);
 		let output = between(&is('('), &is('x'), &is(')'))(&mut input);
-		let mismatch = Mismatch::new(')', 'x');
+		let mismatch = Mismatch::with_expectation(')', 'x');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(
@@ -73,7 +73,7 @@ mod tests {
 	fn fail_no_middle() {
 		let mut input = Input::new_from_chars("()".chars(), None);
 		let output = between(&is('('), &is('x'), &is(')'))(&mut input);
-		let mismatch = Mismatch::new('x', ')');
+		let mismatch = Mismatch::with_expectation('x', ')');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(
@@ -88,7 +88,7 @@ mod tests {
 	fn fail_swap() {
 		let mut input = Input::new_from_chars(")xx(".chars(), None);
 		let output = between(&is('('), &is('x'), &is(')'))(&mut input);
-		let mismatch = Mismatch::new('(', ')');
+		let mismatch = Mismatch::with_expectation('(', ')');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(

--- a/src/combinators/between.rs
+++ b/src/combinators/between.rs
@@ -58,9 +58,14 @@ mod tests {
 	fn fail_repeated() {
 		let mut input = Input::new_from_chars("(xx)".chars(), None);
 		let output = between(&is('('), &is('x'), &is(')'))(&mut input);
+		let mismatch = Mismatch::new(')', 'x');
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 3), None))
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 3),
+				Some(mismatch)
+			))
 		);
 	}
 
@@ -68,9 +73,14 @@ mod tests {
 	fn fail_no_middle() {
 		let mut input = Input::new_from_chars("()".chars(), None);
 		let output = between(&is('('), &is('x'), &is(')'))(&mut input);
+		let mismatch = Mismatch::new('x', ')');
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 2),
+				Some(mismatch)
+			))
 		);
 	}
 
@@ -78,9 +88,14 @@ mod tests {
 	fn fail_swap() {
 		let mut input = Input::new_from_chars(")xx(".chars(), None);
 		let output = between(&is('('), &is('x'), &is(')'))(&mut input);
+		let mismatch = Mismatch::new('(', ')');
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 1),
+				Some(mismatch)
+			))
 		);
 	}
 }

--- a/src/combinators/between.rs
+++ b/src/combinators/between.rs
@@ -58,7 +58,7 @@ mod tests {
 	fn fail_repeated() {
 		let mut input = Input::new_from_chars("(xx)".chars(), None);
 		let output = between(&is('('), &is('x'), &is(')'))(&mut input);
-		let mismatch = Mismatch::with_expectation(')', 'x');
+		let mismatch = Mismatch::new(')', 'x');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(
@@ -73,7 +73,7 @@ mod tests {
 	fn fail_no_middle() {
 		let mut input = Input::new_from_chars("()".chars(), None);
 		let output = between(&is('('), &is('x'), &is(')'))(&mut input);
-		let mismatch = Mismatch::with_expectation('x', ')');
+		let mismatch = Mismatch::new('x', ')');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(
@@ -88,7 +88,7 @@ mod tests {
 	fn fail_swap() {
 		let mut input = Input::new_from_chars(")xx(".chars(), None);
 		let output = between(&is('('), &is('x'), &is(')'))(&mut input);
-		let mismatch = Mismatch::with_expectation('(', ')');
+		let mismatch = Mismatch::new('(', ')');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(

--- a/src/combinators/chain.rs
+++ b/src/combinators/chain.rs
@@ -139,7 +139,7 @@ mod tests {
 		fn empty() {
 			let mut input = Input::new_from_chars("".chars(), None);
 			let output = parse_evaluate_left_subtraction()(&mut input);
-			assert_eq!(output, Err(Error::EndOfInput));
+			assert_eq!(output, Err(Error::EndOfInput(None)));
 		}
 
 		#[test]
@@ -186,7 +186,7 @@ mod tests {
 		fn empty() {
 			let mut input = Input::new_from_chars("".chars(), None);
 			let output = parse_evaluate_right_subtraction()(&mut input);
-			assert_eq!(output, Err(Error::EndOfInput));
+			assert_eq!(output, Err(Error::EndOfInput(None)));
 		}
 
 		#[test]

--- a/src/combinators/choice.rs
+++ b/src/combinators/choice.rs
@@ -40,6 +40,7 @@ where
 			.ok_or(Error::UnexpectedToken(
 				input.source_name(),
 				input.position(),
+				None,
 			))
 	}
 }
@@ -76,7 +77,7 @@ mod tests {
 		let mut input = Input::new_from_chars("u".chars(), None);
 		assert_eq!(
 			parser_choice(&mut input),
-			Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 		);
 		assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 	}
@@ -94,7 +95,7 @@ mod tests {
 		let output = parser_choice(&mut input);
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 		);
 		assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 	}

--- a/src/combinators/count.rs
+++ b/src/combinators/count.rs
@@ -114,7 +114,7 @@ mod tests {
 		let output = parser(&mut input);
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 4)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 4), None))
 		);
 	}
 }

--- a/src/combinators/count.rs
+++ b/src/combinators/count.rs
@@ -112,7 +112,7 @@ mod tests {
 		let mut input = Input::new_from_chars(tokens, None);
 		let parser = count(&parser, 4); // The 4th element is "other", so this should fail.
 		let output = parser(&mut input);
-		let mismatch = Mismatch::new('h', 'x');
+		let mismatch = Mismatch::with_expectation('h', 'x');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(

--- a/src/combinators/count.rs
+++ b/src/combinators/count.rs
@@ -112,7 +112,7 @@ mod tests {
 		let mut input = Input::new_from_chars(tokens, None);
 		let parser = count(&parser, 4); // The 4th element is "other", so this should fail.
 		let output = parser(&mut input);
-		let mismatch = Mismatch::with_expectation('h', 'x');
+		let mismatch = Mismatch::new('h', 'x');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(

--- a/src/combinators/count.rs
+++ b/src/combinators/count.rs
@@ -112,9 +112,14 @@ mod tests {
 		let mut input = Input::new_from_chars(tokens, None);
 		let parser = count(&parser, 4); // The 4th element is "other", so this should fail.
 		let output = parser(&mut input);
+		let mismatch = Mismatch::new('h', 'x');
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 4), None))
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 4),
+				Some(mismatch)
+			))
 		);
 	}
 }

--- a/src/combinators/end_of_input.rs
+++ b/src/combinators/end_of_input.rs
@@ -27,7 +27,7 @@ where
 		None => Ok(()),
 		Some(t) => {
 			let position = t.position();
-			Err(Error::UnexpectedToken(input.source_name(), position))
+			Err(Error::UnexpectedToken(input.source_name(), position, None))
 		}
 	}
 }

--- a/src/combinators/is.rs
+++ b/src/combinators/is.rs
@@ -57,7 +57,7 @@ mod tests {
 		let mut input = Input::new_from_chars("h".chars(), None);
 		assert_eq!(
 			parser(&mut input),
-			Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 		);
 		assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 	}

--- a/src/combinators/is.rs
+++ b/src/combinators/is.rs
@@ -38,7 +38,7 @@ where
 					let position = input_token.position();
 					let expected = token.clone();
 					let found = (*input_token.token()).clone();
-					let mismatch = Mismatch::with_expectation(expected, found);
+					let mismatch = Mismatch::new(expected, found);
 					Err(Error::UnexpectedToken(
 						input.source_name(),
 						position,
@@ -68,7 +68,7 @@ mod tests {
 	fn fail() {
 		let parser = is('j');
 		let mut input = Input::new_from_chars("h".chars(), None);
-		let mismatch = Mismatch::with_expectation('j', 'h');
+		let mismatch = Mismatch::new('j', 'h');
 		assert_eq!(
 			parser(&mut input),
 			Err(Error::UnexpectedToken(

--- a/src/combinators/is.rs
+++ b/src/combinators/is.rs
@@ -46,7 +46,7 @@ where
 					))
 				}
 			}
-			None => Err(Error::EndOfInput),
+			None => Err(Error::EndOfInput(Some(Box::new(token.clone())))),
 		}
 	}
 }

--- a/src/combinators/is.rs
+++ b/src/combinators/is.rs
@@ -1,4 +1,4 @@
-use crate::{InputToken, Parser, satisfy};
+use crate::{Error, InputToken, Mismatch, Parser};
 
 /// Creates a parser that succeeds if the next token in the input equals `token`.
 ///
@@ -26,16 +26,29 @@ use crate::{InputToken, Parser, satisfy};
 /// ```
 pub fn is<IT>(token: IT::Token) -> impl Parser<IT, IT::Token>
 where
-	IT: InputToken,
+	IT: InputToken + 'static,
 {
-	let f = move |t: &IT::Token| {
-		if *t == token {
-			Some((*t).clone())
-		} else {
-			None
+	move |input| {
+		match input.peek() {
+			Some(input_token) => {
+				if token == *input_token.token() {
+					input.next_token(); // Consume if successful.
+					Ok(token.clone())
+				} else {
+					let position = input_token.position();
+					let expected = token.clone();
+					let found = (*input_token.token()).clone();
+					let mismatch = Mismatch::new(expected, found);
+					Err(Error::UnexpectedToken(
+						input.source_name(),
+						position,
+						Some(mismatch),
+					))
+				}
+			}
+			None => Err(Error::EndOfInput),
 		}
-	};
-	satisfy(f)
+	}
 }
 
 #[cfg(test)]
@@ -55,9 +68,14 @@ mod tests {
 	fn fail() {
 		let parser = is('j');
 		let mut input = Input::new_from_chars("h".chars(), None);
+		let mismatch = Mismatch::new('j', 'h');
 		assert_eq!(
 			parser(&mut input),
-			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 1),
+				Some(mismatch)
+			))
 		);
 		assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 	}

--- a/src/combinators/is.rs
+++ b/src/combinators/is.rs
@@ -38,7 +38,7 @@ where
 					let position = input_token.position();
 					let expected = token.clone();
 					let found = (*input_token.token()).clone();
-					let mismatch = Mismatch::new(expected, found);
+					let mismatch = Mismatch::with_expectation(expected, found);
 					Err(Error::UnexpectedToken(
 						input.source_name(),
 						position,
@@ -68,7 +68,7 @@ mod tests {
 	fn fail() {
 		let parser = is('j');
 		let mut input = Input::new_from_chars("h".chars(), None);
-		let mismatch = Mismatch::new('j', 'h');
+		let mismatch = Mismatch::with_expectation('j', 'h');
 		assert_eq!(
 			parser(&mut input),
 			Err(Error::UnexpectedToken(

--- a/src/combinators/look_ahead.rs
+++ b/src/combinators/look_ahead.rs
@@ -13,7 +13,7 @@ use crate::{InputToken, Parser};
 ///
 /// ```
 /// use yapcol::input::Position;
-/// use yapcol::{Error, Input, any, end_of_input, is, look_ahead};
+/// use yapcol::{Error, Input, Mismatch, any, end_of_input, is, look_ahead};
 ///
 /// // Succeeds without consuming input.
 /// let mut input = Input::new_from_chars("123".chars(), None);
@@ -36,9 +36,14 @@ use crate::{InputToken, Parser};
 /// 	Ok((o1, o2))
 /// };
 /// let output = look_ahead(&consuming_parser)(&mut input);
+/// let mismatch = Mismatch::new('1', '3');
 /// assert_eq!(
 /// 	output,
-/// 	Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
+/// 	Err(Error::UnexpectedToken(
+/// 		None,
+/// 		Position::new(1, 2),
+/// 		Some(mismatch)
+/// 	))
 /// );
 /// assert_eq!(any()(&mut input), Ok('3')); // Input was consumed.
 ///
@@ -92,9 +97,14 @@ mod tests {
 		let parser = is('h');
 		let mut input = Input::new_from_chars("j".chars(), None);
 		let output = look_ahead(&parser)(&mut input);
+		let mismatch = Mismatch::new('h', 'j');
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 1),
+				Some(mismatch)
+			))
 		);
 		// Input should still be intact.
 		assert_eq!(any()(&mut input), Ok('j'));
@@ -110,9 +120,14 @@ mod tests {
 			Ok((output1, output2))
 		};
 		let output = look_ahead(&parser)(&mut input);
+		let mismatch = Mismatch::new('a', 'e');
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 2),
+				Some(mismatch)
+			))
 		);
 		// Input was consumed.
 		assert_eq!(any()(&mut input), Ok('e'));
@@ -124,9 +139,14 @@ mod tests {
 		let parser = is('h');
 		let mut input = Input::new_from_chars("jello".chars(), None);
 		let result = look_ahead(&parser)(&mut input);
+		let mismatch = Mismatch::new('h', 'j');
 		assert_eq!(
 			result,
-			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 1),
+				Some(mismatch)
+			))
 		);
 		// Input should still be intact
 		assert_eq!(is('j')(&mut input), Ok('j'));

--- a/src/combinators/look_ahead.rs
+++ b/src/combinators/look_ahead.rs
@@ -36,7 +36,7 @@ use crate::{InputToken, Parser};
 /// 	Ok((o1, o2))
 /// };
 /// let output = look_ahead(&consuming_parser)(&mut input);
-/// let mismatch = Mismatch::new('1', '3');
+/// let mismatch = Mismatch::with_expectation('1', '3');
 /// assert_eq!(
 /// 	output,
 /// 	Err(Error::UnexpectedToken(
@@ -100,7 +100,7 @@ mod tests {
 		let parser = is('h');
 		let mut input = Input::new_from_chars("j".chars(), None);
 		let output = look_ahead(&parser)(&mut input);
-		let mismatch = Mismatch::new('h', 'j');
+		let mismatch = Mismatch::with_expectation('h', 'j');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(
@@ -123,7 +123,7 @@ mod tests {
 			Ok((output1, output2))
 		};
 		let output = look_ahead(&parser)(&mut input);
-		let mismatch = Mismatch::new('a', 'e');
+		let mismatch = Mismatch::with_expectation('a', 'e');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(
@@ -142,7 +142,7 @@ mod tests {
 		let parser = is('h');
 		let mut input = Input::new_from_chars("jello".chars(), None);
 		let result = look_ahead(&parser)(&mut input);
-		let mismatch = Mismatch::new('h', 'j');
+		let mismatch = Mismatch::with_expectation('h', 'j');
 		assert_eq!(
 			result,
 			Err(Error::UnexpectedToken(

--- a/src/combinators/look_ahead.rs
+++ b/src/combinators/look_ahead.rs
@@ -38,7 +38,7 @@ use crate::{InputToken, Parser};
 /// let output = look_ahead(&consuming_parser)(&mut input);
 /// assert_eq!(
 /// 	output,
-/// 	Err(Error::UnexpectedToken(None, Position::new(1, 2)))
+/// 	Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
 /// );
 /// assert_eq!(any()(&mut input), Ok('3')); // Input was consumed.
 ///
@@ -94,7 +94,7 @@ mod tests {
 		let output = look_ahead(&parser)(&mut input);
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 		);
 		// Input should still be intact.
 		assert_eq!(any()(&mut input), Ok('j'));
@@ -112,7 +112,7 @@ mod tests {
 		let output = look_ahead(&parser)(&mut input);
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 2)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
 		);
 		// Input was consumed.
 		assert_eq!(any()(&mut input), Ok('e'));
@@ -126,7 +126,7 @@ mod tests {
 		let result = look_ahead(&parser)(&mut input);
 		assert_eq!(
 			result,
-			Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 		);
 		// Input should still be intact
 		assert_eq!(is('j')(&mut input), Ok('j'));

--- a/src/combinators/look_ahead.rs
+++ b/src/combinators/look_ahead.rs
@@ -74,7 +74,10 @@ mod tests {
 		let parser = is('h');
 		let mut input = Input::new_from_chars("".chars(), None);
 		let parse_look_ahead = look_ahead(&parser)(&mut input);
-		assert_eq!(parse_look_ahead, Err(Error::EndOfInput));
+		assert_eq!(
+			parse_look_ahead,
+			Err(Error::EndOfInput(Some(Box::new('h'))))
+		);
 	}
 
 	#[test]

--- a/src/combinators/look_ahead.rs
+++ b/src/combinators/look_ahead.rs
@@ -36,7 +36,7 @@ use crate::{InputToken, Parser};
 /// 	Ok((o1, o2))
 /// };
 /// let output = look_ahead(&consuming_parser)(&mut input);
-/// let mismatch = Mismatch::with_expectation('1', '3');
+/// let mismatch = Mismatch::new('1', '3');
 /// assert_eq!(
 /// 	output,
 /// 	Err(Error::UnexpectedToken(
@@ -100,7 +100,7 @@ mod tests {
 		let parser = is('h');
 		let mut input = Input::new_from_chars("j".chars(), None);
 		let output = look_ahead(&parser)(&mut input);
-		let mismatch = Mismatch::with_expectation('h', 'j');
+		let mismatch = Mismatch::new('h', 'j');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(
@@ -123,7 +123,7 @@ mod tests {
 			Ok((output1, output2))
 		};
 		let output = look_ahead(&parser)(&mut input);
-		let mismatch = Mismatch::with_expectation('a', 'e');
+		let mismatch = Mismatch::new('a', 'e');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(
@@ -142,7 +142,7 @@ mod tests {
 		let parser = is('h');
 		let mut input = Input::new_from_chars("jello".chars(), None);
 		let result = look_ahead(&parser)(&mut input);
-		let mismatch = Mismatch::with_expectation('h', 'j');
+		let mismatch = Mismatch::new('h', 'j');
 		assert_eq!(
 			result,
 			Err(Error::UnexpectedToken(

--- a/src/combinators/many.rs
+++ b/src/combinators/many.rs
@@ -193,9 +193,14 @@ mod tests {
 			let parser = is('h');
 			let mut input = Input::new_from_chars("jklmno".chars(), None);
 			let parser_many1 = many1(&parser);
+			let mismatch = Mismatch::new('h', 'j');
 			assert_eq!(
 				parser_many1(&mut input),
-				Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
+				Err(Error::UnexpectedToken(
+					None,
+					Position::new(1, 1),
+					Some(mismatch)
+				))
 			);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}
@@ -204,9 +209,14 @@ mod tests {
 		fn no_match_shortcut() {
 			let parser = is('h').many1();
 			let mut input = Input::new_from_chars("jklmno".chars(), None);
+			let mismatch = Mismatch::new('h', 'j');
 			assert_eq!(
 				parser(&mut input),
-				Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
+				Err(Error::UnexpectedToken(
+					None,
+					Position::new(1, 1),
+					Some(mismatch)
+				))
 			);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}

--- a/src/combinators/many.rs
+++ b/src/combinators/many.rs
@@ -199,7 +199,7 @@ mod tests {
 			let parser = is('h');
 			let mut input = Input::new_from_chars("jklmno".chars(), None);
 			let parser_many1 = many1(&parser);
-			let mismatch = Mismatch::new('h', 'j');
+			let mismatch = Mismatch::with_expectation('h', 'j');
 			assert_eq!(
 				parser_many1(&mut input),
 				Err(Error::UnexpectedToken(
@@ -215,7 +215,7 @@ mod tests {
 		fn no_match_shortcut() {
 			let parser = is('h').many1();
 			let mut input = Input::new_from_chars("jklmno".chars(), None);
-			let mismatch = Mismatch::new('h', 'j');
+			let mismatch = Mismatch::with_expectation('h', 'j');
 			assert_eq!(
 				parser(&mut input),
 				Err(Error::UnexpectedToken(

--- a/src/combinators/many.rs
+++ b/src/combinators/many.rs
@@ -178,14 +178,20 @@ mod tests {
 			let parser = is('h');
 			let mut input = Input::new_from_chars("".chars(), None);
 			let parser_many1 = many1(&parser);
-			assert_eq!(parser_many1(&mut input), Err(Error::EndOfInput));
+			assert_eq!(
+				parser_many1(&mut input),
+				Err(Error::EndOfInput(Some(Box::new('h'))))
+			);
 		}
 
 		#[test]
 		fn empty_shortcut() {
 			let parser = is('h').many1();
 			let mut input = Input::new_from_chars("".chars(), None);
-			assert_eq!(parser(&mut input), Err(Error::EndOfInput));
+			assert_eq!(
+				parser(&mut input),
+				Err(Error::EndOfInput(Some(Box::new('h'))))
+			);
 		}
 
 		#[test]

--- a/src/combinators/many.rs
+++ b/src/combinators/many.rs
@@ -195,7 +195,7 @@ mod tests {
 			let parser_many1 = many1(&parser);
 			assert_eq!(
 				parser_many1(&mut input),
-				Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+				Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 			);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}
@@ -206,7 +206,7 @@ mod tests {
 			let mut input = Input::new_from_chars("jklmno".chars(), None);
 			assert_eq!(
 				parser(&mut input),
-				Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+				Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 			);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}

--- a/src/combinators/many.rs
+++ b/src/combinators/many.rs
@@ -199,7 +199,7 @@ mod tests {
 			let parser = is('h');
 			let mut input = Input::new_from_chars("jklmno".chars(), None);
 			let parser_many1 = many1(&parser);
-			let mismatch = Mismatch::with_expectation('h', 'j');
+			let mismatch = Mismatch::new('h', 'j');
 			assert_eq!(
 				parser_many1(&mut input),
 				Err(Error::UnexpectedToken(
@@ -215,7 +215,7 @@ mod tests {
 		fn no_match_shortcut() {
 			let parser = is('h').many1();
 			let mut input = Input::new_from_chars("jklmno".chars(), None);
-			let mismatch = Mismatch::with_expectation('h', 'j');
+			let mismatch = Mismatch::new('h', 'j');
 			assert_eq!(
 				parser(&mut input),
 				Err(Error::UnexpectedToken(

--- a/src/combinators/many_until.rs
+++ b/src/combinators/many_until.rs
@@ -81,7 +81,7 @@ mod tests {
 		let mut input = Input::new_from_chars("xxxxxy".chars(), None);
 		let not_followed_parser = many_until(&any_parser, &end_comment_parser);
 		let output = not_followed_parser(&mut input);
-		let mismatch = Mismatch::with_expectation('x', 'y');
+		let mismatch = Mismatch::new('x', 'y');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(

--- a/src/combinators/many_until.rs
+++ b/src/combinators/many_until.rs
@@ -83,7 +83,7 @@ mod tests {
 		let output = not_followed_parser(&mut input);
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 6)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 6), None))
 		);
 		assert_eq!(any()(&mut input), Ok('y')); // Input was consumed while looking for the end.
 	}

--- a/src/combinators/many_until.rs
+++ b/src/combinators/many_until.rs
@@ -51,7 +51,7 @@ mod tests {
 		let mut input = Input::new_from_chars("".chars(), None);
 		let not_followed_parser = many_until(&any_parser, &end_comment_parser);
 		let output = not_followed_parser(&mut input);
-		assert_eq!(output, Err(Error::EndOfInput));
+		assert_eq!(output, Err(Error::EndOfInput(None)));
 	}
 
 	#[test]

--- a/src/combinators/many_until.rs
+++ b/src/combinators/many_until.rs
@@ -81,7 +81,7 @@ mod tests {
 		let mut input = Input::new_from_chars("xxxxxy".chars(), None);
 		let not_followed_parser = many_until(&any_parser, &end_comment_parser);
 		let output = not_followed_parser(&mut input);
-		let mismatch = Mismatch::new('x', 'y');
+		let mismatch = Mismatch::with_expectation('x', 'y');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(

--- a/src/combinators/many_until.rs
+++ b/src/combinators/many_until.rs
@@ -81,9 +81,14 @@ mod tests {
 		let mut input = Input::new_from_chars("xxxxxy".chars(), None);
 		let not_followed_parser = many_until(&any_parser, &end_comment_parser);
 		let output = not_followed_parser(&mut input);
+		let mismatch = Mismatch::new('x', 'y');
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 6), None))
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 6),
+				Some(mismatch)
+			))
 		);
 		assert_eq!(any()(&mut input), Ok('y')); // Input was consumed while looking for the end.
 	}

--- a/src/combinators/maybe.rs
+++ b/src/combinators/maybe.rs
@@ -95,7 +95,7 @@ mod tests {
 				if token == 'h' {
 					Ok(1)
 				} else {
-					Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+					Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 				}
 			}
 			Err(e) => Err(e),
@@ -104,7 +104,7 @@ mod tests {
 		let parser_maybe = maybe(&parser);
 		assert_eq!(
 			parser_maybe(&mut input),
-			Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 		);
 		assert!(end_of_input()(&mut input).is_ok()); // Ensure that the input was consumed.
 	}

--- a/src/combinators/not_followed_by.rs
+++ b/src/combinators/not_followed_by.rs
@@ -22,7 +22,7 @@ use crate::{Error, InputToken, Parser};
 /// let output = not_followed_parser(&mut input);
 /// assert_eq!(
 /// 	output,
-/// 	Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+/// 	Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 /// );
 /// ```
 pub fn not_followed_by<P, IT, O>(parser: &P) -> impl Parser<IT, ()>
@@ -38,6 +38,7 @@ where
 			Ok(_) => Err(Error::UnexpectedToken(
 				input.source_name(),
 				input.position(),
+				None,
 			)),
 			Err(Error::EndOfInput) => Err(Error::EndOfInput),
 			Err(_) => Ok(()),
@@ -67,7 +68,7 @@ mod tests {
 		let output = not_followed_parser(&mut input);
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 		);
 	}
 
@@ -95,7 +96,7 @@ mod tests {
 		let output = not_followed_parser(&mut input);
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 		);
 	}
 }

--- a/src/combinators/not_followed_by.rs
+++ b/src/combinators/not_followed_by.rs
@@ -40,7 +40,7 @@ where
 				input.position(),
 				None,
 			)),
-			Err(Error::EndOfInput) => Err(Error::EndOfInput),
+			Err(Error::EndOfInput(oe)) => Err(Error::EndOfInput(oe)),
 			Err(_) => Ok(()),
 		}
 	}
@@ -57,7 +57,7 @@ mod tests {
 		let mut input = Input::new_from_chars("".chars(), None);
 		let not_followed_parser = not_followed_by(&parser);
 		let output = not_followed_parser(&mut input);
-		assert_eq!(output, Err(Error::EndOfInput));
+		assert_eq!(output, Err(Error::EndOfInput(Some(Box::new('h')))));
 	}
 
 	#[test]

--- a/src/combinators/option.rs
+++ b/src/combinators/option.rs
@@ -84,9 +84,14 @@ mod tests {
 		let parser2 = is('j');
 		let mut input = Input::new_from_chars("kello".chars(), None);
 		let parse_option = option(&parser1, &parser2);
+		let mismatch = Mismatch::new('j', 'k');
 		assert_eq!(
 			parse_option(&mut input),
-			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 1),
+				Some(mismatch)
+			))
 		);
 		assert_eq!(any()(&mut input), Ok('k')); // Ensure that the input was NOT consumed.
 	}
@@ -102,9 +107,14 @@ mod tests {
 		};
 		let parse_option = option(&consuming_parser, &parser2);
 		let output = parse_option(&mut input);
+		let mismatch = Mismatch::new('j', 'e');
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 2),
+				Some(mismatch)
+			))
 		);
 		assert_eq!(any()(&mut input), Ok('e')); // Ensure that the input was consumed.
 	}

--- a/src/combinators/option.rs
+++ b/src/combinators/option.rs
@@ -86,7 +86,7 @@ mod tests {
 		let parse_option = option(&parser1, &parser2);
 		assert_eq!(
 			parse_option(&mut input),
-			Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 		);
 		assert_eq!(any()(&mut input), Ok('k')); // Ensure that the input was NOT consumed.
 	}
@@ -104,7 +104,7 @@ mod tests {
 		let output = parse_option(&mut input);
 		assert_eq!(
 			output,
-			Err(Error::UnexpectedToken(None, Position::new(1, 2)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
 		);
 		assert_eq!(any()(&mut input), Ok('e')); // Ensure that the input was consumed.
 	}

--- a/src/combinators/option.rs
+++ b/src/combinators/option.rs
@@ -84,7 +84,7 @@ mod tests {
 		let parser2 = is('j');
 		let mut input = Input::new_from_chars("kello".chars(), None);
 		let parse_option = option(&parser1, &parser2);
-		let mismatch = Mismatch::new('j', 'k');
+		let mismatch = Mismatch::with_expectation('j', 'k');
 		assert_eq!(
 			parse_option(&mut input),
 			Err(Error::UnexpectedToken(
@@ -107,7 +107,7 @@ mod tests {
 		};
 		let parse_option = option(&consuming_parser, &parser2);
 		let output = parse_option(&mut input);
-		let mismatch = Mismatch::new('j', 'e');
+		let mismatch = Mismatch::with_expectation('j', 'e');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(

--- a/src/combinators/option.rs
+++ b/src/combinators/option.rs
@@ -84,7 +84,7 @@ mod tests {
 		let parser2 = is('j');
 		let mut input = Input::new_from_chars("kello".chars(), None);
 		let parse_option = option(&parser1, &parser2);
-		let mismatch = Mismatch::with_expectation('j', 'k');
+		let mismatch = Mismatch::new('j', 'k');
 		assert_eq!(
 			parse_option(&mut input),
 			Err(Error::UnexpectedToken(
@@ -107,7 +107,7 @@ mod tests {
 		};
 		let parse_option = option(&consuming_parser, &parser2);
 		let output = parse_option(&mut input);
-		let mismatch = Mismatch::with_expectation('j', 'e');
+		let mismatch = Mismatch::new('j', 'e');
 		assert_eq!(
 			output,
 			Err(Error::UnexpectedToken(

--- a/src/combinators/satisfy.rs
+++ b/src/combinators/satisfy.rs
@@ -1,4 +1,4 @@
-use crate::{Error, InputToken, Parser};
+use crate::{Error, InputToken, Mismatch, Parser};
 
 /// Creates a parser that succeeds if the given predicate returns `Some` for the next token.
 ///
@@ -42,7 +42,12 @@ where
 					}
 					None => {
 						let position = input_token.position();
-						Err(Error::UnexpectedToken(input.source_name(), position, None))
+						let mismatch = Mismatch::without_expectation(token.to_string());
+						Err(Error::UnexpectedToken(
+							input.source_name(),
+							position,
+							Some(mismatch),
+						))
 					}
 				}
 			}
@@ -71,9 +76,14 @@ mod tests {
 		assert!(end_of_input()(&mut input).is_ok());
 		// Words fails and does not consume.
 		let mut input = Input::new_from_chars("hello".chars(), None);
+		let mismatch = Mismatch::without_expectation('h');
 		assert_eq!(
 			parser(&mut input),
-			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 1),
+				Some(mismatch)
+			))
 		);
 		assert_eq!(any()(&mut input), Ok('h'));
 		assert_eq!(any()(&mut input), Ok('e'));

--- a/src/combinators/satisfy.rs
+++ b/src/combinators/satisfy.rs
@@ -46,7 +46,7 @@ where
 					}
 				}
 			}
-			None => Err(Error::EndOfInput),
+			None => Err(Error::EndOfInput(None)),
 		}
 	}
 }

--- a/src/combinators/satisfy.rs
+++ b/src/combinators/satisfy.rs
@@ -42,7 +42,7 @@ where
 					}
 					None => {
 						let position = input_token.position();
-						Err(Error::UnexpectedToken(input.source_name(), position))
+						Err(Error::UnexpectedToken(input.source_name(), position, None))
 					}
 				}
 			}
@@ -73,7 +73,7 @@ mod tests {
 		let mut input = Input::new_from_chars("hello".chars(), None);
 		assert_eq!(
 			parser(&mut input),
-			Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+			Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 		);
 		assert_eq!(any()(&mut input), Ok('h'));
 		assert_eq!(any()(&mut input), Ok('e'));

--- a/src/combinators/separated_by.rs
+++ b/src/combinators/separated_by.rs
@@ -133,7 +133,7 @@ mod tests {
 			let parse_separator = is(',');
 			let mut input = Input::new_from_chars("1,2".chars(), None);
 			let output = separated_by0(&parse_item, &parse_separator)(&mut input);
-			let mismatch = Mismatch::with_expectation('1', '2');
+			let mismatch = Mismatch::new('1', '2');
 			assert_eq!(
 				output,
 				Err(Error::UnexpectedToken(
@@ -177,7 +177,7 @@ mod tests {
 			let parse_separator = is(',');
 			let mut input = Input::new_from_chars("1,1,1,1,1,1,1,1,1,1,2".chars(), None);
 			let output = separated_by0(&parse_item, &parse_separator)(&mut input);
-			let mismatch = Mismatch::with_expectation('1', '2');
+			let mismatch = Mismatch::new('1', '2');
 			assert_eq!(
 				output,
 				Err(Error::UnexpectedToken(
@@ -235,7 +235,7 @@ mod tests {
 			let parse_separator = is(',');
 			let mut input = Input::new_from_chars("1,2".chars(), None);
 			let output = separated_by1(&parse_item, &parse_separator)(&mut input);
-			let mismatch = Mismatch::with_expectation('1', '2');
+			let mismatch = Mismatch::new('1', '2');
 			assert_eq!(
 				output,
 				Err(Error::UnexpectedToken(
@@ -279,7 +279,7 @@ mod tests {
 			let parse_separator = is(',');
 			let mut input = Input::new_from_chars("1,1,1,1,1,1,1,1,1,1,2".chars(), None);
 			let output = separated_by1(&parse_item, &parse_separator)(&mut input);
-			let mismatch = Mismatch::with_expectation('1', '2');
+			let mismatch = Mismatch::new('1', '2');
 			assert_eq!(
 				output,
 				Err(Error::UnexpectedToken(

--- a/src/combinators/separated_by.rs
+++ b/src/combinators/separated_by.rs
@@ -133,7 +133,7 @@ mod tests {
 			let parse_separator = is(',');
 			let mut input = Input::new_from_chars("1,2".chars(), None);
 			let output = separated_by0(&parse_item, &parse_separator)(&mut input);
-			let mismatch = Mismatch::new('1', '2');
+			let mismatch = Mismatch::with_expectation('1', '2');
 			assert_eq!(
 				output,
 				Err(Error::UnexpectedToken(
@@ -177,7 +177,7 @@ mod tests {
 			let parse_separator = is(',');
 			let mut input = Input::new_from_chars("1,1,1,1,1,1,1,1,1,1,2".chars(), None);
 			let output = separated_by0(&parse_item, &parse_separator)(&mut input);
-			let mismatch = Mismatch::new('1', '2');
+			let mismatch = Mismatch::with_expectation('1', '2');
 			assert_eq!(
 				output,
 				Err(Error::UnexpectedToken(
@@ -235,7 +235,7 @@ mod tests {
 			let parse_separator = is(',');
 			let mut input = Input::new_from_chars("1,2".chars(), None);
 			let output = separated_by1(&parse_item, &parse_separator)(&mut input);
-			let mismatch = Mismatch::new('1', '2');
+			let mismatch = Mismatch::with_expectation('1', '2');
 			assert_eq!(
 				output,
 				Err(Error::UnexpectedToken(
@@ -279,7 +279,7 @@ mod tests {
 			let parse_separator = is(',');
 			let mut input = Input::new_from_chars("1,1,1,1,1,1,1,1,1,1,2".chars(), None);
 			let output = separated_by1(&parse_item, &parse_separator)(&mut input);
-			let mismatch = Mismatch::new('1', '2');
+			let mismatch = Mismatch::with_expectation('1', '2');
 			assert_eq!(
 				output,
 				Err(Error::UnexpectedToken(

--- a/src/combinators/separated_by.rs
+++ b/src/combinators/separated_by.rs
@@ -135,7 +135,7 @@ mod tests {
 			let output = separated_by0(&parse_item, &parse_separator)(&mut input);
 			assert_eq!(
 				output,
-				Err(Error::UnexpectedToken(None, Position::new(1, 3)))
+				Err(Error::UnexpectedToken(None, Position::new(1, 3), None))
 			);
 		}
 
@@ -174,7 +174,7 @@ mod tests {
 			let output = separated_by0(&parse_item, &parse_separator)(&mut input);
 			assert_eq!(
 				output,
-				Err(Error::UnexpectedToken(None, Position::new(1, 21)))
+				Err(Error::UnexpectedToken(None, Position::new(1, 21), None))
 			);
 		}
 	}
@@ -227,7 +227,7 @@ mod tests {
 			let output = separated_by1(&parse_item, &parse_separator)(&mut input);
 			assert_eq!(
 				output,
-				Err(Error::UnexpectedToken(None, Position::new(1, 3)))
+				Err(Error::UnexpectedToken(None, Position::new(1, 3), None))
 			);
 		}
 
@@ -266,7 +266,7 @@ mod tests {
 			let output = separated_by1(&parse_item, &parse_separator)(&mut input);
 			assert_eq!(
 				output,
-				Err(Error::UnexpectedToken(None, Position::new(1, 21)))
+				Err(Error::UnexpectedToken(None, Position::new(1, 21), None))
 			);
 		}
 	}

--- a/src/combinators/separated_by.rs
+++ b/src/combinators/separated_by.rs
@@ -48,7 +48,7 @@ where
 			let output = vec![token];
 			separated_tail(&parser, &separator)(input, output)
 		}
-		Err(Error::EndOfInput) => Ok(vec![]),
+		Err(Error::EndOfInput(_)) => Ok(vec![]),
 		Err(_) => Ok(vec![]),
 	}
 }
@@ -115,7 +115,7 @@ mod tests {
 			let parse_separator = is(',');
 			let mut input = Input::new_from_chars("1,".chars(), None);
 			let output = separated_by0(&parse_item, &parse_separator)(&mut input);
-			assert_eq!(output, Err(Error::EndOfInput));
+			assert_eq!(output, Err(Error::EndOfInput(Some(Box::new('1')))));
 		}
 
 		#[test]
@@ -168,7 +168,7 @@ mod tests {
 			let parse_separator = is(',');
 			let mut input = Input::new_from_chars("1,1,1,1,1,1,1,1,1,1,".chars(), None);
 			let output = separated_by0(&parse_item, &parse_separator)(&mut input);
-			assert_eq!(output, Err(Error::EndOfInput));
+			assert_eq!(output, Err(Error::EndOfInput(Some(Box::new('1')))));
 		}
 
 		#[test]
@@ -199,7 +199,7 @@ mod tests {
 			let parse_separator = is(',');
 			let mut input = Input::new_from_chars("".chars(), None);
 			let output = separated_by1(&parse_item, &parse_separator)(&mut input);
-			assert_eq!(output, Err(Error::EndOfInput));
+			assert_eq!(output, Err(Error::EndOfInput(Some(Box::new('1')))));
 		}
 
 		#[test]
@@ -217,7 +217,7 @@ mod tests {
 			let parse_separator = is(',');
 			let mut input = Input::new_from_chars("1,".chars(), None);
 			let output = separated_by1(&parse_item, &parse_separator)(&mut input);
-			assert_eq!(output, Err(Error::EndOfInput));
+			assert_eq!(output, Err(Error::EndOfInput(Some(Box::new('1')))));
 		}
 
 		#[test]
@@ -270,7 +270,7 @@ mod tests {
 			let parse_separator = is(',');
 			let mut input = Input::new_from_chars("1,1,1,1,1,1,1,1,1,1,".chars(), None);
 			let output = separated_by1(&parse_item, &parse_separator)(&mut input);
-			assert_eq!(output, Err(Error::EndOfInput));
+			assert_eq!(output, Err(Error::EndOfInput(Some(Box::new('1')))));
 		}
 
 		#[test]

--- a/src/combinators/separated_by.rs
+++ b/src/combinators/separated_by.rs
@@ -133,9 +133,14 @@ mod tests {
 			let parse_separator = is(',');
 			let mut input = Input::new_from_chars("1,2".chars(), None);
 			let output = separated_by0(&parse_item, &parse_separator)(&mut input);
+			let mismatch = Mismatch::new('1', '2');
 			assert_eq!(
 				output,
-				Err(Error::UnexpectedToken(None, Position::new(1, 3), None))
+				Err(Error::UnexpectedToken(
+					None,
+					Position::new(1, 3),
+					Some(mismatch)
+				))
 			);
 		}
 
@@ -172,9 +177,14 @@ mod tests {
 			let parse_separator = is(',');
 			let mut input = Input::new_from_chars("1,1,1,1,1,1,1,1,1,1,2".chars(), None);
 			let output = separated_by0(&parse_item, &parse_separator)(&mut input);
+			let mismatch = Mismatch::new('1', '2');
 			assert_eq!(
 				output,
-				Err(Error::UnexpectedToken(None, Position::new(1, 21), None))
+				Err(Error::UnexpectedToken(
+					None,
+					Position::new(1, 21),
+					Some(mismatch)
+				))
 			);
 		}
 	}
@@ -225,9 +235,14 @@ mod tests {
 			let parse_separator = is(',');
 			let mut input = Input::new_from_chars("1,2".chars(), None);
 			let output = separated_by1(&parse_item, &parse_separator)(&mut input);
+			let mismatch = Mismatch::new('1', '2');
 			assert_eq!(
 				output,
-				Err(Error::UnexpectedToken(None, Position::new(1, 3), None))
+				Err(Error::UnexpectedToken(
+					None,
+					Position::new(1, 3),
+					Some(mismatch)
+				))
 			);
 		}
 
@@ -264,9 +279,14 @@ mod tests {
 			let parse_separator = is(',');
 			let mut input = Input::new_from_chars("1,1,1,1,1,1,1,1,1,1,2".chars(), None);
 			let output = separated_by1(&parse_item, &parse_separator)(&mut input);
+			let mismatch = Mismatch::new('1', '2');
 			assert_eq!(
 				output,
-				Err(Error::UnexpectedToken(None, Position::new(1, 21), None))
+				Err(Error::UnexpectedToken(
+					None,
+					Position::new(1, 21),
+					Some(mismatch)
+				))
 			);
 		}
 	}

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,19 +7,32 @@
 use crate::input::Position;
 use std::fmt::{Debug, Display};
 
+pub trait MismatchElement: Display + Debug {}
+
+impl<T> MismatchElement for T where T: Display + Debug {}
+
 pub struct Mismatch {
-	expected: Box<dyn Display>,
-	found: Box<dyn Display>,
+	expected: Box<dyn MismatchElement>,
+	found: Box<dyn MismatchElement>,
 }
 
 impl Mismatch {
-	pub fn new<T>(expected: T, found: T) -> Mismatch
+	pub fn new<E1, E2>(expected: E1, found: E2) -> Mismatch
 	where
-		T: Display + Clone + 'static,
+		E1: MismatchElement + Clone + 'static,
+		E2: MismatchElement + Clone + 'static,
 	{
 		let expected = Box::new(expected.clone());
 		let found = Box::new(found.clone());
 		Mismatch { expected, found }
+	}
+
+	pub fn same(om1: &Option<Mismatch>, om2: &Option<Mismatch>) -> bool {
+		match (om1, om2) {
+			(None, None) => true,
+			(Some(m1), Some(m2)) => m1.expected.to_string() == m2.expected.to_string(),
+			_ => false,
+		}
 	}
 }
 
@@ -65,7 +78,7 @@ impl Debug for Mismatch {
 ///
 /// // Fails with EndOfInput when the stream is exhausted.
 /// is('a')(&mut input).unwrap(); // Consume the only token
-/// assert_eq!(any()(&mut input), Err(Error::EndOfInput));
+/// assert_eq!(any()(&mut input), Err(Error::EndOfInput(None)));
 /// ```
 #[derive(Debug)]
 pub enum Error {
@@ -75,21 +88,19 @@ pub enum Error {
 	/// position (in the input source) where the unexpected token was found.
 	UnexpectedToken(Option<String>, Position, Option<Mismatch>),
 	/// The input stream was exhausted before the parser could match.
-	EndOfInput,
+	EndOfInput(Option<Box<dyn MismatchElement>>),
 }
 
 impl PartialEq for Error {
 	fn eq(&self, other: &Self) -> bool {
 		match (self, other) {
-			(Error::EndOfInput, Error::EndOfInput) => true,
-			(Error::UnexpectedToken(s1, p1, e1), Error::UnexpectedToken(s2, p2, e2)) => {
-				match (e1, e2) {
-					(Some(e1), Some(e2)) => {
-						s1 == s2 && p1 == p2 && e1.to_string() == e2.to_string()
-					}
-					(None, None) => true,
-					_ => false,
-				}
+			(Error::EndOfInput(om1), Error::EndOfInput(om2)) => match (om1, om2) {
+				(None, None) => true,
+				(Some(e1), Some(e2)) => e1.to_string() == e2.to_string(),
+				_ => false,
+			},
+			(Error::UnexpectedToken(s1, p1, om1), Error::UnexpectedToken(s2, p2, om2)) => {
+				s1 == s2 && p1 == p2 && Mismatch::same(om1, om2)
 			}
 			_ => false,
 		}
@@ -102,15 +113,25 @@ impl Display for Error {
 			Error::UnexpectedToken(Some(source_name), pos, None) => {
 				write!(f, "Unexpected token at {}:{}.", source_name, pos)
 			}
-			Error::UnexpectedToken(Some(source_name), pos, Some(expectation)) => {
+			Error::UnexpectedToken(Some(source_name), pos, Some(mismatch)) => {
 				write!(
 					f,
 					"Unexpected token at {source_name}:{pos}. Expected: {}, found: {}",
-					expectation.expected, expectation.found
+					mismatch.expected, mismatch.found
 				)
 			}
-			Error::UnexpectedToken(None, pos, _) => write!(f, "Unexpected token at {}.", pos),
-			Error::EndOfInput => write!(f, "End of input reached."),
+			Error::UnexpectedToken(None, pos, None) => write!(f, "Unexpected token at {pos}."),
+			Error::UnexpectedToken(None, pos, Some(mismatch)) => {
+				write!(
+					f,
+					"Unexpected token at {pos}. Expected: {}, found: {}",
+					mismatch.expected, mismatch.found
+				)
+			}
+			Error::EndOfInput(Some(expected)) => {
+				write!(f, "End of input reached when expected {}.", expected)
+			}
+			Error::EndOfInput(None) => write!(f, "End of input reached."),
 		}
 	}
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,12 @@ pub struct Mismatch {
 }
 
 impl Mismatch {
-	pub fn new(expected: Box<dyn Display>, found: Box<dyn Display>) -> Mismatch {
+	pub fn new<T>(expected: T, found: T) -> Mismatch
+	where
+		T: Display + Clone + 'static,
+	{
+		let expected = Box::new(expected.clone());
+		let found = Box::new(found.clone());
 		Mismatch { expected, found }
 	}
 }
@@ -26,7 +31,7 @@ impl Display for Mismatch {
 
 impl Debug for Mismatch {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		Display::fmt(&self, f)
+		Display::fmt(self, f)
 	}
 }
 
@@ -40,16 +45,22 @@ impl Debug for Mismatch {
 ///
 /// ```
 /// use yapcol::input::Position;
-/// use yapcol::{Error, Input, any, is};
+/// use yapcol::{Error, Input, Mismatch, any, is};
 ///
 /// let tokens = vec!['a'];
 /// let source_name = Some(String::from("file.txt"));
 /// let mut input = Input::new_from_chars(tokens, source_name.clone());
 ///
 /// // Fails with UnexpectedToken when the token does not match.
+/// let output = is('b')(&mut input);
+/// let mismatch = Mismatch::new('b', 'a');
 /// assert_eq!(
-/// 	is('b')(&mut input),
-/// 	Err(Error::UnexpectedToken(source_name, Position::new(1, 1), None))
+/// 	output,
+/// 	Err(Error::UnexpectedToken(
+/// 		source_name,
+/// 		Position::new(1, 1),
+/// 		Some(mismatch)
+/// 	))
 /// );
 ///
 /// // Fails with EndOfInput when the stream is exhausted.
@@ -94,8 +105,8 @@ impl Display for Error {
 			Error::UnexpectedToken(Some(source_name), pos, Some(expectation)) => {
 				write!(
 					f,
-					"Unexpected token at {}:{}. Expected: {}, found: {}",
-					source_name, pos, expectation.expected, expectation.found
+					"Unexpected token at {source_name}:{pos}. Expected: {}, found: {}",
+					expectation.expected, expectation.found
 				)
 			}
 			Error::UnexpectedToken(None, pos, _) => write!(f, "Unexpected token at {}.", pos),

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,13 +17,14 @@ impl PartialEq for dyn MismatchElement {
 	}
 }
 
+#[derive(PartialEq, Debug)]
 pub struct Mismatch {
 	expected: Option<Box<dyn MismatchElement>>,
-	found: Box<dyn MismatchElement>,
+	found: Option<Box<dyn MismatchElement>>,
 }
 
 impl Mismatch {
-	pub fn with_expectation<E1, E2>(expected: E1, found: E2) -> Mismatch
+	pub fn new<E1, E2>(expected: E1, found: E2) -> Mismatch
 	where
 		E1: MismatchElement + 'static,
 		E2: MismatchElement + 'static,
@@ -32,7 +33,18 @@ impl Mismatch {
 		let found = Box::new(found);
 		Mismatch {
 			expected: Some(expected),
-			found,
+			found: Some(found),
+		}
+	}
+
+	pub fn without_found<E>(expected: E) -> Mismatch
+	where
+		E: MismatchElement + 'static,
+	{
+		let expected = Box::new(expected);
+		Mismatch {
+			expected: Some(expected),
+			found: None,
 		}
 	}
 
@@ -43,7 +55,7 @@ impl Mismatch {
 		let found = Box::new(found);
 		Mismatch {
 			expected: None,
-			found,
+			found: Some(found),
 		}
 	}
 
@@ -58,39 +70,14 @@ impl Mismatch {
 impl Display for Mismatch {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self.expected {
-			Some(ref expected) => {
-				write!(f, "Expected: {}, found: {}", expected, self.found)
-			}
-			None => write!(f, "Found: {}", self.found),
-		}
-	}
-}
-
-impl PartialEq for Mismatch {
-	fn eq(&self, other: &Self) -> bool {
-		if *self.found == *other.found {
-			match self.expected {
-				Some(ref expected) => match other.expected {
-					Some(ref other_expected) => expected == other_expected,
-					None => false,
-				},
-				None => other.expected.is_none(),
-			}
-		} else {
-			false
-		}
-	}
-}
-
-impl Debug for Mismatch {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		match self.expected {
-			Some(ref expected) => write!(
-				f,
-				"Mismatch {{ expected: {}, found: {} }}",
-				expected, self.found
-			),
-			None => write!(f, "Mismatch {{ found: {} }}", self.found),
+			Some(ref expected) => match self.found {
+				Some(ref found) => write!(f, "Expected: {expected}, found: {found}"),
+				None => write!(f, "Expected: {expected}"),
+			},
+			None => match self.found {
+				Some(ref found) => write!(f, "Found: {found}"),
+				None => panic!("Invalid error mismatch."),
+			},
 		}
 	}
 }
@@ -113,7 +100,7 @@ impl Debug for Mismatch {
 ///
 /// // Fails with UnexpectedToken when the token does not match.
 /// let output = is('b')(&mut input);
-/// let mismatch = Mismatch::with_expectation('b', 'a');
+/// let mismatch = Mismatch::new('b', 'a');
 /// assert_eq!(
 /// 	output,
 /// 	Err(Error::UnexpectedToken(
@@ -170,8 +157,8 @@ mod tests {
 
 		#[test]
 		fn same_with_expectation_equal() {
-			let m1 = Mismatch::with_expectation("h", "p");
-			let m2 = Mismatch::with_expectation("h", "p");
+			let m1 = Mismatch::new("h", "p");
+			let m2 = Mismatch::new("h", "p");
 			assert_eq!(m1, m2);
 		}
 
@@ -184,22 +171,22 @@ mod tests {
 
 		#[test]
 		fn different_expectation_presence() {
-			let m1 = Mismatch::with_expectation("hello", "p");
+			let m1 = Mismatch::new("hello", "p");
 			let m2 = Mismatch::without_expectation("hello");
 			assert_ne!(m1, m2);
 		}
 
 		#[test]
 		fn different_expectation() {
-			let m1 = Mismatch::with_expectation("hello", "p");
-			let m2 = Mismatch::with_expectation("hallo", "p");
+			let m1 = Mismatch::new("hello", "p");
+			let m2 = Mismatch::new("hallo", "p");
 			assert_ne!(m1, m2);
 		}
 
 		#[test]
 		fn different_found() {
-			let m1 = Mismatch::with_expectation("hello", "p");
-			let m2 = Mismatch::with_expectation("hello", "x");
+			let m1 = Mismatch::new("hello", "p");
+			let m2 = Mismatch::new("hello", "x");
 			assert_ne!(m1, m2);
 		}
 	}

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,30 @@
 //! cases.
 
 use crate::input::Position;
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
+
+pub struct Mismatch {
+	expected: Box<dyn Display>,
+	found: Box<dyn Display>,
+}
+
+impl Mismatch {
+	pub fn new(expected: Box<dyn Display>, found: Box<dyn Display>) -> Mismatch {
+		Mismatch { expected, found }
+	}
+}
+
+impl Display for Mismatch {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "Expected: {}, found: {}", self.expected, self.found)
+	}
+}
+
+impl Debug for Mismatch {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		Display::fmt(&self, f)
+	}
+}
 
 /// The error type returned by all parsers in this crate.
 ///
@@ -26,31 +49,56 @@ use std::fmt::Display;
 /// // Fails with UnexpectedToken when the token does not match.
 /// assert_eq!(
 /// 	is('b')(&mut input),
-/// 	Err(Error::UnexpectedToken(source_name, Position::new(1, 1)))
+/// 	Err(Error::UnexpectedToken(source_name, Position::new(1, 1), None))
 /// );
 ///
 /// // Fails with EndOfInput when the stream is exhausted.
 /// is('a')(&mut input).unwrap(); // Consume the only token
 /// assert_eq!(any()(&mut input), Err(Error::EndOfInput));
 /// ```
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Debug)]
 pub enum Error {
 	/// The next token was present but did not satisfy the parser's requirements.
 	///
 	/// The first field is the optional source name (e.g. a file name), and the second is the
 	/// position (in the input source) where the unexpected token was found.
-	UnexpectedToken(Option<String>, Position),
+	UnexpectedToken(Option<String>, Position, Option<Mismatch>),
 	/// The input stream was exhausted before the parser could match.
 	EndOfInput,
+}
+
+impl PartialEq for Error {
+	fn eq(&self, other: &Self) -> bool {
+		match (self, other) {
+			(Error::EndOfInput, Error::EndOfInput) => true,
+			(Error::UnexpectedToken(s1, p1, e1), Error::UnexpectedToken(s2, p2, e2)) => {
+				match (e1, e2) {
+					(Some(e1), Some(e2)) => {
+						s1 == s2 && p1 == p2 && e1.to_string() == e2.to_string()
+					}
+					(None, None) => true,
+					_ => false,
+				}
+			}
+			_ => false,
+		}
+	}
 }
 
 impl Display for Error {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
-			Error::UnexpectedToken(Some(source_name), pos) => {
+			Error::UnexpectedToken(Some(source_name), pos, None) => {
 				write!(f, "Unexpected token at {}:{}.", source_name, pos)
 			}
-			Error::UnexpectedToken(None, pos) => write!(f, "Unexpected token at {}.", pos),
+			Error::UnexpectedToken(Some(source_name), pos, Some(expectation)) => {
+				write!(
+					f,
+					"Unexpected token at {}:{}. Expected: {}, found: {}",
+					source_name, pos, expectation.expected, expectation.found
+				)
+			}
+			Error::UnexpectedToken(None, pos, _) => write!(f, "Unexpected token at {}.", pos),
 			Error::EndOfInput => write!(f, "End of input reached."),
 		}
 	}

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,40 +11,87 @@ pub trait MismatchElement: Display + Debug {}
 
 impl<T> MismatchElement for T where T: Display + Debug {}
 
+impl PartialEq for dyn MismatchElement {
+	fn eq(&self, other: &Self) -> bool {
+		self.to_string() == other.to_string()
+	}
+}
+
 pub struct Mismatch {
-	expected: Box<dyn MismatchElement>,
+	expected: Option<Box<dyn MismatchElement>>,
 	found: Box<dyn MismatchElement>,
 }
 
 impl Mismatch {
-	pub fn new<E1, E2>(expected: E1, found: E2) -> Mismatch
+	pub fn with_expectation<E1, E2>(expected: E1, found: E2) -> Mismatch
 	where
-		E1: MismatchElement + Clone + 'static,
-		E2: MismatchElement + Clone + 'static,
+		E1: MismatchElement + 'static,
+		E2: MismatchElement + 'static,
 	{
-		let expected = Box::new(expected.clone());
-		let found = Box::new(found.clone());
-		Mismatch { expected, found }
+		let expected = Box::new(expected);
+		let found = Box::new(found);
+		Mismatch {
+			expected: Some(expected),
+			found,
+		}
 	}
 
-	pub fn same(om1: &Option<Mismatch>, om2: &Option<Mismatch>) -> bool {
-		match (om1, om2) {
-			(None, None) => true,
-			(Some(m1), Some(m2)) => m1.expected.to_string() == m2.expected.to_string(),
-			_ => false,
+	pub fn without_expectation<E>(found: E) -> Mismatch
+	where
+		E: MismatchElement + 'static,
+	{
+		let found = Box::new(found);
+		Mismatch {
+			expected: None,
+			found,
 		}
+	}
+
+	pub fn replace_expectation<E>(&mut self, expected: E)
+	where
+		E: MismatchElement + 'static,
+	{
+		self.expected.replace(Box::new(expected));
 	}
 }
 
 impl Display for Mismatch {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(f, "Expected: {}, found: {}", self.expected, self.found)
+		match self.expected {
+			Some(ref expected) => {
+				write!(f, "Expected: {}, found: {}", expected, self.found)
+			}
+			None => write!(f, "Found: {}", self.found),
+		}
+	}
+}
+
+impl PartialEq for Mismatch {
+	fn eq(&self, other: &Self) -> bool {
+		if *self.found == *other.found {
+			match self.expected {
+				Some(ref expected) => match other.expected {
+					Some(ref other_expected) => expected == other_expected,
+					None => false,
+				},
+				None => other.expected.is_none(),
+			}
+		} else {
+			false
+		}
 	}
 }
 
 impl Debug for Mismatch {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		Display::fmt(self, f)
+		match self.expected {
+			Some(ref expected) => write!(
+				f,
+				"Mismatch {{ expected: {}, found: {} }}",
+				expected, self.found
+			),
+			None => write!(f, "Mismatch {{ found: {} }}", self.found),
+		}
 	}
 }
 
@@ -66,7 +113,7 @@ impl Debug for Mismatch {
 ///
 /// // Fails with UnexpectedToken when the token does not match.
 /// let output = is('b')(&mut input);
-/// let mismatch = Mismatch::new('b', 'a');
+/// let mismatch = Mismatch::with_expectation('b', 'a');
 /// assert_eq!(
 /// 	output,
 /// 	Err(Error::UnexpectedToken(
@@ -80,31 +127,18 @@ impl Debug for Mismatch {
 /// is('a')(&mut input).unwrap(); // Consume the only token
 /// assert_eq!(any()(&mut input), Err(Error::EndOfInput(None)));
 /// ```
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
 	/// The next token was present but did not satisfy the parser's requirements.
 	///
-	/// The first field is the optional source name (e.g. a file name), and the second is the
-	/// position (in the input source) where the unexpected token was found.
+	/// The first field is the optional source name (e.g., a file name). The second is the
+	/// position (in the input source) where the unexpected token was found. The third field is an
+	/// optional mismatch, detailing what was found and what was expected.
 	UnexpectedToken(Option<String>, Position, Option<Mismatch>),
 	/// The input stream was exhausted before the parser could match.
+	///
+	/// It contains an optional mismatch element, describing what was expected.
 	EndOfInput(Option<Box<dyn MismatchElement>>),
-}
-
-impl PartialEq for Error {
-	fn eq(&self, other: &Self) -> bool {
-		match (self, other) {
-			(Error::EndOfInput(om1), Error::EndOfInput(om2)) => match (om1, om2) {
-				(None, None) => true,
-				(Some(e1), Some(e2)) => e1.to_string() == e2.to_string(),
-				_ => false,
-			},
-			(Error::UnexpectedToken(s1, p1, om1), Error::UnexpectedToken(s2, p2, om2)) => {
-				s1 == s2 && p1 == p2 && Mismatch::same(om1, om2)
-			}
-			_ => false,
-		}
-	}
 }
 
 impl Display for Error {
@@ -114,24 +148,59 @@ impl Display for Error {
 				write!(f, "Unexpected token at {}:{}.", source_name, pos)
 			}
 			Error::UnexpectedToken(Some(source_name), pos, Some(mismatch)) => {
-				write!(
-					f,
-					"Unexpected token at {source_name}:{pos}. Expected: {}, found: {}",
-					mismatch.expected, mismatch.found
-				)
+				write!(f, "Unexpected token at {source_name}:{pos}. {mismatch}")
 			}
 			Error::UnexpectedToken(None, pos, None) => write!(f, "Unexpected token at {pos}."),
 			Error::UnexpectedToken(None, pos, Some(mismatch)) => {
-				write!(
-					f,
-					"Unexpected token at {pos}. Expected: {}, found: {}",
-					mismatch.expected, mismatch.found
-				)
+				write!(f, "Unexpected token at {pos}. {mismatch}")
 			}
 			Error::EndOfInput(Some(expected)) => {
 				write!(f, "End of input reached when expected {}.", expected)
 			}
 			Error::EndOfInput(None) => write!(f, "End of input reached."),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+
+	mod mismatch {
+		use crate::Mismatch;
+
+		#[test]
+		fn same_with_expectation_equal() {
+			let m1 = Mismatch::with_expectation("h", "p");
+			let m2 = Mismatch::with_expectation("h", "p");
+			assert_eq!(m1, m2);
+		}
+
+		#[test]
+		fn same_without_expectation_equal() {
+			let m1 = Mismatch::without_expectation("hello");
+			let m2 = Mismatch::without_expectation("hello");
+			assert_eq!(m1, m2);
+		}
+
+		#[test]
+		fn different_expectation_presence() {
+			let m1 = Mismatch::with_expectation("hello", "p");
+			let m2 = Mismatch::without_expectation("hello");
+			assert_ne!(m1, m2);
+		}
+
+		#[test]
+		fn different_expectation() {
+			let m1 = Mismatch::with_expectation("hello", "p");
+			let m2 = Mismatch::with_expectation("hallo", "p");
+			assert_ne!(m1, m2);
+		}
+
+		#[test]
+		fn different_found() {
+			let m1 = Mismatch::with_expectation("hello", "p");
+			let m2 = Mismatch::with_expectation("hello", "x");
+			assert_ne!(m1, m2);
 		}
 	}
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,9 @@
 use crate::input::Position;
 use std::fmt::{Debug, Display};
 
+/// A trait for types that can be used as elements in a [`Mismatch`].
+///
+/// Any type that implements both [`Display`] and [`Debug`] automatically implements this trait.
 pub trait MismatchElement: Display + Debug {}
 
 impl<T> MismatchElement for T where T: Display + Debug {}
@@ -17,6 +20,12 @@ impl PartialEq for dyn MismatchElement {
 	}
 }
 
+/// Describes a mismatch between what was expected and what was found during parsing.
+///
+/// A `Mismatch` is carried by [`Error::UnexpectedToken`] and [`Error::EndOfInput`] to provide
+/// human-readable context about why a parser failed. Both the `expected` and `found` fields are
+/// optional: use [`Mismatch::new`] when both are known, [`Mismatch::without_found`] when only the
+/// expectation is known, and [`Mismatch::without_expectation`] when only the found value is known.
 #[derive(PartialEq, Debug)]
 pub struct Mismatch {
 	expected: Option<Box<dyn MismatchElement>>,
@@ -24,6 +33,7 @@ pub struct Mismatch {
 }
 
 impl Mismatch {
+	/// Creates a `Mismatch` with both an expected value and a found value.
 	pub fn new<E1, E2>(expected: E1, found: E2) -> Mismatch
 	where
 		E1: MismatchElement + 'static,
@@ -37,6 +47,7 @@ impl Mismatch {
 		}
 	}
 
+	/// Creates a `Mismatch` with only an expected value, when no token was found (e.g., end of input).
 	pub fn without_found<E>(expected: E) -> Mismatch
 	where
 		E: MismatchElement + 'static,
@@ -48,6 +59,7 @@ impl Mismatch {
 		}
 	}
 
+	/// Creates a `Mismatch` with only a found value, when no expectation is available.
 	pub fn without_expectation<E>(found: E) -> Mismatch
 	where
 		E: MismatchElement + 'static,
@@ -59,6 +71,7 @@ impl Mismatch {
 		}
 	}
 
+	/// Replaces the expected value of this `Mismatch`, overwriting any previously set expectation.
 	pub fn replace_expectation<E>(&mut self, expected: E)
 	where
 		E: MismatchElement + 'static,

--- a/src/input/core.rs
+++ b/src/input/core.rs
@@ -16,6 +16,7 @@ use std::fmt::{Debug, Display};
 ///
 /// - `Token`: The underlying token value type.
 pub trait InputToken: Clone {
+	/// The underlying token, without any extra parsing-related data.
 	type Token: PartialEq + Clone + Display + Debug;
 
 	/// Returns a reference to the underlying token value.

--- a/src/input/core.rs
+++ b/src/input/core.rs
@@ -3,6 +3,7 @@ use crate::input::lookahead::{LookAheadFrame, LookAheadHandler, TokenLocation};
 use crate::input::source::InputSource;
 use crate::input::token::TokenInputSource;
 use std::collections::VecDeque;
+use std::fmt::Display;
 
 /// Represents a single token in the input stream.
 ///
@@ -15,7 +16,7 @@ use std::collections::VecDeque;
 ///
 /// - `Token`: The underlying token value type.
 pub trait InputToken: Clone {
-	type Token: PartialEq + Clone;
+	type Token: PartialEq + Clone + Display;
 
 	/// Returns a reference to the underlying token value.
 	fn token(&self) -> &Self::Token;

--- a/src/input/core.rs
+++ b/src/input/core.rs
@@ -3,7 +3,7 @@ use crate::input::lookahead::{LookAheadFrame, LookAheadHandler, TokenLocation};
 use crate::input::source::InputSource;
 use crate::input::token::TokenInputSource;
 use std::collections::VecDeque;
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 
 /// Represents a single token in the input stream.
 ///
@@ -16,7 +16,7 @@ use std::fmt::Display;
 ///
 /// - `Token`: The underlying token value type.
 pub trait InputToken: Clone {
-	type Token: PartialEq + Clone + Display;
+	type Token: PartialEq + Clone + Display + Debug;
 
 	/// Returns a reference to the underlying token value.
 	fn token(&self) -> &Self::Token;

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -22,7 +22,7 @@
 //!
 //! ## Character-based parsing
 //!
-//! Use [`core::Input::new_from_chars`], which wraps a `char` iterator and automatically
+//! Use [`Input::new_from_chars`], which wraps a `char` iterator and automatically
 //! tracks source positions:
 //!
 //! ```
@@ -37,7 +37,7 @@
 //! tokens, implement [`InputToken`] on your token type and use [`Input::new_from_tokens`]:
 //!
 //! ```rust,ignore
-//! use yapcol::input::core::Input;
+//! use yapcol::Input;
 //!
 //! let tokens: Vec<MyToken> = lexer.tokenize(source);
 //! let mut input = Input::new_from_tokens(tokens, None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,10 +43,11 @@
 //! Every parser returns a `Result<Output, Error>`. When parsing fails, the `Err` variant contains
 //! one of two possible errors, defined in the [`Error`] enum:
 //!
-//! - [`Error::UnexpectedToken`]`(Option<String>, Position)`: the
+//! - [`Error::UnexpectedToken`]`(Option<String>, Position, Option<Mismatch>)`: the
 //!   parser encountered a token that did not satisfy its requirements. The first field is an
-//!   optional source name (e.g., a file name), and the second is the [`input::Position`] (line and
-//!   column) where the unexpected token was found.
+//!   optional source name (e.g., a file name). The second is the [`input::Position`] (line and
+//!   column) where the unexpected token was found. The third field is an optional [`Mismatch`]
+//!   describing what was expected versus what was found.
 //! - [`Error::EndOfInput`]: the input stream was exhausted before the parser could match.
 //!
 //! The code below showcases both error variants in a simple character-based parsing example:
@@ -75,8 +76,7 @@
 //! assert_eq!(any()(&mut input), Err(Error::EndOfInput(None)));
 //! ```
 //!
-//! The [`Error`] type implements [`std::fmt::Display`], so you can easily print human-readable
-//! error messages.
+//! The [`Error`] type implements [`std::fmt::Display`], so you can print human-readable error messages.
 //!
 //! ```
 //! use yapcol::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,15 +53,21 @@
 //!
 //! ```
 //! use yapcol::input::Position;
-//! use yapcol::{Error, Input, any, is};
+//! use yapcol::{Error, Input, Mismatch, any, is};
 //!
 //! let source_name = Some(String::from("file.txt"));
 //! let mut input = Input::new_from_chars(vec!['a'], source_name.clone());
 //!
 //! // Fails with UnexpectedToken when the token does not match.
+//! let output = is('b')(&mut input);
+//! let mismatch = Mismatch::new('b', 'a');
 //! assert_eq!(
-//! 	is('b')(&mut input),
-//! 	Err(Error::UnexpectedToken(source_name, Position::new(1, 1), None))
+//! 	output,
+//! 	Err(Error::UnexpectedToken(
+//! 		source_name,
+//! 		Position::new(1, 1),
+//! 		Some(mismatch)
+//! 	))
 //! );
 //!
 //! // Consume the only token, then try to read more.
@@ -104,6 +110,6 @@ pub mod input;
 mod parser;
 
 pub use combinators::*;
-pub use error::Error;
+pub use error::{Error, Mismatch};
 pub use input::{CharToken, Input, InputToken, StringInput};
 pub use parser::{Parser, StringParser};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 //!
 //! // Fails with UnexpectedToken when the token does not match.
 //! let output = is('b')(&mut input);
-//! let mismatch = Mismatch::with_expectation('b', 'a');
+//! let mismatch = Mismatch::new('b', 'a');
 //! assert_eq!(
 //! 	output,
 //! 	Err(Error::UnexpectedToken(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //!
 //! // Consume the only token, then try to read more.
 //! is('a')(&mut input).unwrap();
-//! assert_eq!(any()(&mut input), Err(Error::EndOfInput));
+//! assert_eq!(any()(&mut input), Err(Error::EndOfInput(None)));
 //! ```
 //!
 //! The [`Error`] type implements [`std::fmt::Display`], so you can easily print human-readable
@@ -85,7 +85,7 @@
 //! let error = Error::UnexpectedToken(Some("file.txt".to_string()), Position::new(3, 12), None);
 //! assert_eq!(error.to_string(), "Unexpected token at file.txt:3:12.");
 //!
-//! let error = Error::EndOfInput;
+//! let error = Error::EndOfInput(None);
 //! assert_eq!(error.to_string(), "End of input reached.");
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //! // Fails with UnexpectedToken when the token does not match.
 //! assert_eq!(
 //! 	is('b')(&mut input),
-//! 	Err(Error::UnexpectedToken(source_name, Position::new(1, 1)))
+//! 	Err(Error::UnexpectedToken(source_name, Position::new(1, 1), None))
 //! );
 //!
 //! // Consume the only token, then try to read more.
@@ -76,7 +76,7 @@
 //! use yapcol::Error;
 //! use yapcol::input::Position;
 //!
-//! let error = Error::UnexpectedToken(Some("file.txt".to_string()), Position::new(3, 12));
+//! let error = Error::UnexpectedToken(Some("file.txt".to_string()), Position::new(3, 12), None);
 //! assert_eq!(error.to_string(), "Unexpected token at file.txt:3:12.");
 //!
 //! let error = Error::EndOfInput;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 //!
 //! // Fails with UnexpectedToken when the token does not match.
 //! let output = is('b')(&mut input);
-//! let mismatch = Mismatch::new('b', 'a');
+//! let mismatch = Mismatch::with_expectation('b', 'a');
 //! assert_eq!(
 //! 	output,
 //! 	Err(Error::UnexpectedToken(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -253,7 +253,10 @@ mod tests {
 		fn empty() {
 			let parser = is('2').map(|c: char| c.to_digit(10));
 			let mut input = Input::new_from_chars("".chars(), None);
-			assert_eq!(parser(&mut input), Err(Error::EndOfInput));
+			assert_eq!(
+				parser(&mut input),
+				Err(Error::EndOfInput(Some(Box::new('2'))))
+			);
 		}
 
 		#[test]
@@ -319,7 +322,10 @@ mod tests {
 		fn empty() {
 			let double_parser = is('2').and_then(is);
 			let mut input = Input::new_from_chars("".chars(), None);
-			assert_eq!(double_parser(&mut input), Err(Error::EndOfInput));
+			assert_eq!(
+				double_parser(&mut input),
+				Err(Error::EndOfInput(Some(Box::new('2'))))
+			);
 		}
 
 		#[test]
@@ -379,7 +385,10 @@ mod tests {
 		fn empty() {
 			let double_parser = is('2').and(is('3'));
 			let mut input = Input::new_from_chars("".chars(), None);
-			assert_eq!(double_parser(&mut input), Err(Error::EndOfInput));
+			assert_eq!(
+				double_parser(&mut input),
+				Err(Error::EndOfInput(Some(Box::new('2'))))
+			);
 		}
 
 		#[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,7 +26,7 @@
 //! automatically implemented for any function `Fn(&mut StringInput) -> Result<Output, Error>`.
 
 use crate::combinators::*;
-use crate::error::Error;
+use crate::error::{Error, MismatchElement};
 use crate::input::{CharToken, Input, InputToken, StringInput};
 
 /// The core trait of the `yapcol` crate, representing a parser.
@@ -73,6 +73,21 @@ pub trait Parser<IT, O>: Fn(&mut Input<IT>) -> Result<O, Error>
 where
 	IT: InputToken,
 {
+	fn with_expectation<E>(self, expectation: E) -> impl Parser<IT, O>
+	where
+		E: MismatchElement + Clone + 'static,
+		Self: Sized,
+	{
+		move |input| match self(input) {
+			Ok(result) => Ok(result),
+			Err(Error::EndOfInput(Some(e))) => Err(Error::EndOfInput(Some(e))),
+			Err(Error::EndOfInput(None)) => {
+				Err(Error::EndOfInput(Some(Box::new(expectation.clone()))))
+			}
+			Err(e) => Err(e),
+		}
+	}
+
 	/// Transforms the output of the current parser using the provided function.
 	///
 	/// # Parameters

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -74,6 +74,36 @@ pub trait Parser<IT, O>: Fn(&mut Input<IT>) -> Result<O, Error>
 where
 	IT: InputToken,
 {
+	/// Overrides the expectation in the potential error returned by the current parser in the case
+	/// of failure.
+	///
+	/// When a parser fails, the error may contain information about what was expected. This method
+	/// replaces that expectation with the provided value, which is useful for producing clearer
+	/// error messages.
+	///
+	/// # Parameters
+	/// - `self`: The current parser.
+	/// - `expectation`: The value to use as the new expectation in any error produced by the
+	///   current parser.
+	///
+	/// # Returns
+	/// A new parser that behaves identically to the current one on success, but replaces the
+	/// expectation in any error with `expectation`.
+	///
+	/// # Examples
+	/// ```rust
+	/// use yapcol::{Input, Parser, is};
+	///
+	/// let parser = is('A').with_expectation("uppercase A");
+	///
+	/// let mut input = Input::new_from_chars("B".chars(), None);
+	/// let error = parser(&mut input).unwrap_err();
+	/// assert!(error.to_string().contains("uppercase A"));
+	/// ```
+	///
+	/// # Errors
+	/// If the current parser fails, the error is returned with its expectation replaced by
+	/// `expectation`.
 	fn with_expectation<E>(self, expectation: E) -> impl Parser<IT, O>
 	where
 		E: MismatchElement + Clone + 'static,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -279,9 +279,14 @@ mod tests {
 		fn fail_simple() {
 			let parser = is('2').map(|c: char| c.to_digit(10));
 			let mut input = Input::new_from_chars("3".chars(), None);
+			let mismatch = Mismatch::new('2', '3');
 			assert_eq!(
 				parser(&mut input),
-				Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
+				Err(Error::UnexpectedToken(
+					None,
+					Position::new(1, 1),
+					Some(mismatch)
+				))
 			);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}
@@ -293,9 +298,14 @@ mod tests {
 				.map(|o| o.unwrap())
 				.map(|x| x * 7);
 			let mut input = Input::new_from_chars("3".chars(), None);
+			let mismatch = Mismatch::new('5', '3');
 			assert_eq!(
 				parser(&mut input),
-				Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
+				Err(Error::UnexpectedToken(
+					None,
+					Position::new(1, 1),
+					Some(mismatch)
+				))
 			);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}
@@ -332,9 +342,14 @@ mod tests {
 		fn fail_simple() {
 			let double_parser = is('2').and_then(is);
 			let mut input = Input::new_from_chars("23".chars(), None);
+			let mismatch = Mismatch::new('2', '3');
 			assert_eq!(
 				double_parser(&mut input),
-				Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
+				Err(Error::UnexpectedToken(
+					None,
+					Position::new(1, 2),
+					Some(mismatch)
+				))
 			);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}
@@ -343,9 +358,14 @@ mod tests {
 		fn fail_chained() {
 			let triple_parser = is('2').and_then(is).and_then(is);
 			let mut input = Input::new_from_chars("223".chars(), None);
+			let mismatch = Mismatch::new('2', '3');
 			assert_eq!(
 				triple_parser(&mut input),
-				Err(Error::UnexpectedToken(None, Position::new(1, 3), None))
+				Err(Error::UnexpectedToken(
+					None,
+					Position::new(1, 3),
+					Some(mismatch)
+				))
 			);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}
@@ -382,9 +402,14 @@ mod tests {
 		fn fail_simple() {
 			let double_parser = is('2').and(is('3'));
 			let mut input = Input::new_from_chars("22".chars(), None);
+			let mismatch = Mismatch::new('3', '2');
 			assert_eq!(
 				double_parser(&mut input),
-				Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
+				Err(Error::UnexpectedToken(
+					None,
+					Position::new(1, 2),
+					Some(mismatch)
+				))
 			);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}
@@ -393,9 +418,14 @@ mod tests {
 		fn fail_chained() {
 			let triple_parser = is('2').and(is('3')).and(is('4'));
 			let mut input = Input::new_from_chars("233".chars(), None);
+			let mismatch = Mismatch::new('4', '3');
 			assert_eq!(
 				triple_parser(&mut input),
-				Err(Error::UnexpectedToken(None, Position::new(1, 3), None))
+				Err(Error::UnexpectedToken(
+					None,
+					Position::new(1, 3),
+					Some(mismatch)
+				))
 			);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -84,6 +84,10 @@ where
 			Err(Error::EndOfInput(None)) => {
 				Err(Error::EndOfInput(Some(Box::new(expectation.clone()))))
 			}
+			Err(Error::UnexpectedToken(s, p, Some(mut mismatch))) => {
+				mismatch.replace_expectation(expectation.clone());
+				Err(Error::UnexpectedToken(s, p, Some(mismatch)))
+			}
 			Err(e) => Err(e),
 		}
 	}
@@ -297,7 +301,7 @@ mod tests {
 		fn fail_simple() {
 			let parser = is('2').map(|c: char| c.to_digit(10));
 			let mut input = Input::new_from_chars("3".chars(), None);
-			let mismatch = Mismatch::new('2', '3');
+			let mismatch = Mismatch::with_expectation('2', '3');
 			assert_eq!(
 				parser(&mut input),
 				Err(Error::UnexpectedToken(
@@ -316,7 +320,7 @@ mod tests {
 				.map(|o| o.unwrap())
 				.map(|x| x * 7);
 			let mut input = Input::new_from_chars("3".chars(), None);
-			let mismatch = Mismatch::new('5', '3');
+			let mismatch = Mismatch::with_expectation('5', '3');
 			assert_eq!(
 				parser(&mut input),
 				Err(Error::UnexpectedToken(
@@ -363,7 +367,7 @@ mod tests {
 		fn fail_simple() {
 			let double_parser = is('2').and_then(is);
 			let mut input = Input::new_from_chars("23".chars(), None);
-			let mismatch = Mismatch::new('2', '3');
+			let mismatch = Mismatch::with_expectation('2', '3');
 			assert_eq!(
 				double_parser(&mut input),
 				Err(Error::UnexpectedToken(
@@ -379,7 +383,7 @@ mod tests {
 		fn fail_chained() {
 			let triple_parser = is('2').and_then(is).and_then(is);
 			let mut input = Input::new_from_chars("223".chars(), None);
-			let mismatch = Mismatch::new('2', '3');
+			let mismatch = Mismatch::with_expectation('2', '3');
 			assert_eq!(
 				triple_parser(&mut input),
 				Err(Error::UnexpectedToken(
@@ -426,7 +430,7 @@ mod tests {
 		fn fail_simple() {
 			let double_parser = is('2').and(is('3'));
 			let mut input = Input::new_from_chars("22".chars(), None);
-			let mismatch = Mismatch::new('3', '2');
+			let mismatch = Mismatch::with_expectation('3', '2');
 			assert_eq!(
 				double_parser(&mut input),
 				Err(Error::UnexpectedToken(
@@ -442,7 +446,7 @@ mod tests {
 		fn fail_chained() {
 			let triple_parser = is('2').and(is('3')).and(is('4'));
 			let mut input = Input::new_from_chars("233".chars(), None);
-			let mismatch = Mismatch::new('4', '3');
+			let mismatch = Mismatch::with_expectation('4', '3');
 			assert_eq!(
 				triple_parser(&mut input),
 				Err(Error::UnexpectedToken(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -281,7 +281,7 @@ mod tests {
 			let mut input = Input::new_from_chars("3".chars(), None);
 			assert_eq!(
 				parser(&mut input),
-				Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+				Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 			);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}
@@ -295,7 +295,7 @@ mod tests {
 			let mut input = Input::new_from_chars("3".chars(), None);
 			assert_eq!(
 				parser(&mut input),
-				Err(Error::UnexpectedToken(None, Position::new(1, 1)))
+				Err(Error::UnexpectedToken(None, Position::new(1, 1), None))
 			);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}
@@ -334,7 +334,7 @@ mod tests {
 			let mut input = Input::new_from_chars("23".chars(), None);
 			assert_eq!(
 				double_parser(&mut input),
-				Err(Error::UnexpectedToken(None, Position::new(1, 2)))
+				Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
 			);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}
@@ -345,7 +345,7 @@ mod tests {
 			let mut input = Input::new_from_chars("223".chars(), None);
 			assert_eq!(
 				triple_parser(&mut input),
-				Err(Error::UnexpectedToken(None, Position::new(1, 3)))
+				Err(Error::UnexpectedToken(None, Position::new(1, 3), None))
 			);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}
@@ -384,7 +384,7 @@ mod tests {
 			let mut input = Input::new_from_chars("22".chars(), None);
 			assert_eq!(
 				double_parser(&mut input),
-				Err(Error::UnexpectedToken(None, Position::new(1, 2)))
+				Err(Error::UnexpectedToken(None, Position::new(1, 2), None))
 			);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}
@@ -395,7 +395,7 @@ mod tests {
 			let mut input = Input::new_from_chars("233".chars(), None);
 			assert_eq!(
 				triple_parser(&mut input),
-				Err(Error::UnexpectedToken(None, Position::new(1, 3)))
+				Err(Error::UnexpectedToken(None, Position::new(1, 3), None))
 			);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -25,6 +25,7 @@
 //! convenience trait, which is a specialization of [`Parser`] for char-based input. It is
 //! automatically implemented for any function `Fn(&mut StringInput) -> Result<Output, Error>`.
 
+use crate::Mismatch;
 use crate::combinators::*;
 use crate::error::{Error, MismatchElement};
 use crate::input::{CharToken, Input, InputToken, StringInput};
@@ -80,7 +81,10 @@ where
 	{
 		move |input| match self(input) {
 			Ok(result) => Ok(result),
-			Err(Error::EndOfInput(Some(e))) => Err(Error::EndOfInput(Some(e))),
+			Err(Error::EndOfInput(Some(_))) => {
+				// Replace the expectation.
+				Err(Error::EndOfInput(Some(Box::new(expectation.clone()))))
+			}
 			Err(Error::EndOfInput(None)) => {
 				Err(Error::EndOfInput(Some(Box::new(expectation.clone()))))
 			}
@@ -88,7 +92,10 @@ where
 				mismatch.replace_expectation(expectation.clone());
 				Err(Error::UnexpectedToken(s, p, Some(mismatch)))
 			}
-			Err(e) => Err(e),
+			Err(Error::UnexpectedToken(s, p, None)) => {
+				let mismatch = Mismatch::without_found(expectation.clone());
+				Err(Error::UnexpectedToken(s, p, Some(mismatch)))
+			}
 		}
 	}
 
@@ -301,7 +308,7 @@ mod tests {
 		fn fail_simple() {
 			let parser = is('2').map(|c: char| c.to_digit(10));
 			let mut input = Input::new_from_chars("3".chars(), None);
-			let mismatch = Mismatch::with_expectation('2', '3');
+			let mismatch = Mismatch::new('2', '3');
 			assert_eq!(
 				parser(&mut input),
 				Err(Error::UnexpectedToken(
@@ -320,7 +327,7 @@ mod tests {
 				.map(|o| o.unwrap())
 				.map(|x| x * 7);
 			let mut input = Input::new_from_chars("3".chars(), None);
-			let mismatch = Mismatch::with_expectation('5', '3');
+			let mismatch = Mismatch::new('5', '3');
 			assert_eq!(
 				parser(&mut input),
 				Err(Error::UnexpectedToken(
@@ -367,7 +374,7 @@ mod tests {
 		fn fail_simple() {
 			let double_parser = is('2').and_then(is);
 			let mut input = Input::new_from_chars("23".chars(), None);
-			let mismatch = Mismatch::with_expectation('2', '3');
+			let mismatch = Mismatch::new('2', '3');
 			assert_eq!(
 				double_parser(&mut input),
 				Err(Error::UnexpectedToken(
@@ -383,7 +390,7 @@ mod tests {
 		fn fail_chained() {
 			let triple_parser = is('2').and_then(is).and_then(is);
 			let mut input = Input::new_from_chars("223".chars(), None);
-			let mismatch = Mismatch::with_expectation('2', '3');
+			let mismatch = Mismatch::new('2', '3');
 			assert_eq!(
 				triple_parser(&mut input),
 				Err(Error::UnexpectedToken(
@@ -430,7 +437,7 @@ mod tests {
 		fn fail_simple() {
 			let double_parser = is('2').and(is('3'));
 			let mut input = Input::new_from_chars("22".chars(), None);
-			let mismatch = Mismatch::with_expectation('3', '2');
+			let mismatch = Mismatch::new('3', '2');
 			assert_eq!(
 				double_parser(&mut input),
 				Err(Error::UnexpectedToken(
@@ -446,7 +453,7 @@ mod tests {
 		fn fail_chained() {
 			let triple_parser = is('2').and(is('3')).and(is('4'));
 			let mut input = Input::new_from_chars("233".chars(), None);
-			let mismatch = Mismatch::with_expectation('4', '3');
+			let mismatch = Mismatch::new('4', '3');
 			assert_eq!(
 				triple_parser(&mut input),
 				Err(Error::UnexpectedToken(


### PR DESCRIPTION
This PR adds `expected` and `found` fields to errors, drastically improving the value of error messages.


Closes #9.