### PR TITLE
Release 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yapcol"
 description = "Yet Another Parser Combinator Library - YAPCoL"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "MIT"
 authors = ["Matheus Amazonas"]

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ cargo add yapcol
 
 `yapcol` provides a wide range of built-in combinators:
 
-- Basic: `is`, `satisfy`, `any`, `end_of_input`.
+- Basic: `is`, `satisfy`, `any`, `end_of_input`, `success`.
 - Choice and Optional: `choice`, `maybe`, `either`.
-- Repetition: `many0`, `many1`, `count`, `many_until`, `separated_by0`, `separated_by1`.
+- Repetition: `many0`, `many0_up_to`, `many1`, `many1_up_to`, `count`, `many_until`, `separated_by0`, `separated_by1`.
 - Lookahead and Backtracking: `attempt`, `look_ahead`, `not_followed_by`.
 - Grouping: `between`.
 - Associativity: `chain_left`, `chain_right`.

--- a/src/combinators/many.rs
+++ b/src/combinators/many.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Input, InputToken, Mismatch, Parser};
+use crate::{Error, InputToken, Mismatch, Parser};
 
 /// Applies `parser` zero or more times.
 ///
@@ -55,10 +55,7 @@ where
 	P: Parser<IT, O>,
 	IT: InputToken,
 {
-	|input| {
-		let output: Vec<O> = Vec::new();
-		many(parser, None)(input, output)
-	}
+	many(parser, 0, None)
 }
 
 /// Applies `parser` one or more times.
@@ -114,17 +111,7 @@ where
 	P: Parser<IT, O>,
 	IT: InputToken,
 {
-	|input| {
-		let mut output: Vec<O> = Vec::new();
-		// Parse manually once to ensure that at least one occurrence of the parser succeeds.
-		match parser(input) {
-			Ok(token) => {
-				output.push(token);
-				many(parser, None)(input, output)
-			}
-			Err(e) => Err(e),
-		}
-	}
+	many(parser, 1, None)
 }
 
 /// Applies `parser` between 0 and a given number of times, ensuring that no more matches occur.
@@ -200,28 +187,7 @@ where
 	P: Parser<IT, O>,
 	IT: InputToken,
 {
-	move |input| {
-		let mut output: Vec<O> = Vec::new();
-		match parser(input) {
-			Ok(_) if max_count == 0 => {
-				let position = input.position();
-				let expected = "no occurrences".to_string();
-				let found = "at least one occurrence".to_string();
-				let mismatch = Mismatch::new(expected, found);
-				Err(Error::UnexpectedToken(
-					input.source_name(),
-					position,
-					Some(mismatch),
-				))
-			}
-			Ok(token) => {
-				output.push(token);
-				// One occurence has been consumed, so request `max_count - 1`.
-				many(parser, Some(max_count - 1))(input, output)
-			}
-			Err(_) => Ok(output),
-		}
-	}
+	many(parser, 0, Some(max_count))
 }
 
 /// Applies `parser` between 1 and a given number of times, ensuring that no more matches occur.
@@ -303,34 +269,37 @@ where
 	if max_count == 0 {
 		panic!("max_count must be greater than 0");
 	}
-	move |input| {
-		let mut output: Vec<O> = Vec::new();
-		// Parse manually once to ensure that at least one occurrence of the parser succeeds.
-		match parser(input) {
-			Ok(token) => {
-				output.push(token);
-				// One occurence has been consumed, so request `max_count - 1`.
-				many(parser, Some(max_count - 1))(input, output)
-			}
-			Err(e) => Err(e),
-		}
-	}
+	many(parser, 1, Some(max_count))
 }
 
-fn many<P, IT, O>(
-	parser: &P,
-	max_count: Option<usize>,
-) -> impl Fn(&mut Input<IT>, Vec<O>) -> Result<Vec<O>, Error>
+fn many<P, IT, O>(parser: &P, min_count: usize, max_count: Option<usize>) -> impl Parser<IT, Vec<O>>
 where
 	P: Parser<IT, O>,
 	IT: InputToken,
 {
-	move |input, mut output| {
+	move |input| {
+		let mut matches: Vec<O> = Vec::new();
 		let mut total_count = 0;
 		let mut previous_count: Option<usize> = None;
 		loop {
-			match parser(input) {
-				Ok(token) => {
+			let previous_position = input.position();
+			let parse_outcome = parser(input);
+			match (parse_outcome, max_count) {
+				(Ok(_), Some(max_count)) if max_count == total_count => {
+					// Matched too many times.
+					total_count += 1;
+					let expected = format!("at most {max_count} occurrences");
+					let found = format!("{total_count} occurrences");
+					let mismatch = Mismatch::new(expected, found);
+					return Err(Error::UnexpectedToken(
+						input.source_name(),
+						previous_position,
+						Some(mismatch),
+					));
+				}
+				(Ok(token), _) => {
+					// Valid match.
+					total_count += 1;
 					let new_count = input.consumed_count();
 					// Check if non-consuming parser. If so, it would cause an infinite loop.
 					if let Some(previous) = previous_count
@@ -341,28 +310,14 @@ where
 							input.position(),
 						));
 					}
-					output.push(token);
+					matches.push(token);
 					previous_count = Some(new_count);
-					total_count += 1;
 				}
-				Err(_) => {
-					return match max_count {
-						None => Ok(output),
-						Some(max_count) => {
-							if total_count <= max_count {
-								Ok(output)
-							} else {
-								let position = input.position();
-								let expected = format!("at most {max_count} occurrences");
-								let found = format!("{total_count} occurrences");
-								let mismatch = Mismatch::new(expected, found);
-								Err(Error::UnexpectedToken(
-									input.source_name(),
-									position,
-									Some(mismatch),
-								))
-							}
-						}
+				(Err(e), _) => {
+					return if total_count >= min_count {
+						Ok(matches)
+					} else {
+						Err(e)
 					};
 				}
 			}
@@ -372,6 +327,37 @@ where
 
 #[cfg(test)]
 mod tests {
+	use crate::Error;
+	use crate::input::Position;
+	use std::fmt::Debug;
+
+	fn assert_unexpected_error<T>(
+		value: Result<T, Error>,
+		position: Position,
+		expected: &str,
+		found: &str,
+	) where
+		T: Debug,
+	{
+		let error = value.unwrap_err();
+		if let Error::UnexpectedToken(_, error_pos, mismatch) = error {
+			if error_pos != position {
+				panic!("Expected error position to be {position}, but got {error_pos}");
+			}
+			let mismatch_message = mismatch.unwrap().to_string();
+			let mut split = mismatch_message.split("found:");
+			let expected_message = split.next().unwrap();
+			assert!(expected_message.contains(expected));
+			let found_message = split.next().unwrap();
+			assert!(found_message.contains(found));
+		} else {
+			panic!(
+				"Expected error to be of type UnexpectedToken, but got {:?}",
+				error
+			);
+		}
+	}
+
 	mod many0 {
 		use crate::input::Position;
 		use crate::*;
@@ -618,6 +604,8 @@ mod tests {
 	}
 
 	mod many0_up_to {
+		use super::assert_unexpected_error;
+		use crate::input::Position;
 		use crate::*;
 
 		#[test]
@@ -698,7 +686,8 @@ mod tests {
 			let mut input = Input::new_from_chars("hhhhello".chars(), None);
 			let parser_up_to = many0_up_to(&parser, 3);
 			let output = parser_up_to(&mut input);
-			assert!(output.is_err());
+			let position = Position::new(1, 4);
+			assert_unexpected_error(output, position, "3", "4");
 		}
 
 		#[test]
@@ -729,7 +718,8 @@ mod tests {
 			let mut input = Input::new_from_chars("hello".chars(), None);
 			let parser_up_to = many0_up_to(&parser, 0);
 			let output = parser_up_to(&mut input);
-			assert!(output.is_err());
+			let position = Position::new(1, 1);
+			assert_unexpected_error(output, position, "0", "1");
 			assert_eq!(input.consumed_count(), 1);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 			assert_eq!(any()(&mut input), Ok('e'));
@@ -737,7 +727,7 @@ mod tests {
 	}
 
 	mod many1_up_to {
-		use crate::combinators::many::many1_up_to;
+		use super::assert_unexpected_error;
 		use crate::input::Position;
 		use crate::*;
 
@@ -767,15 +757,9 @@ mod tests {
 			let parser = is('h');
 			let mut input = Input::new_from_chars("jklmno".chars(), None);
 			let parser_up_to = many1_up_to(&parser, 1);
-			let mismatch = Mismatch::new('h', 'j');
-			assert_eq!(
-				parser_up_to(&mut input),
-				Err(Error::UnexpectedToken(
-					None,
-					Position::new(1, 1),
-					Some(mismatch)
-				))
-			);
+			let output = parser_up_to(&mut input);
+			let position = Position::new(1, 1);
+			assert_unexpected_error(output, position, "h", "j");
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}
 
@@ -783,15 +767,9 @@ mod tests {
 		fn no_match_shortcut() {
 			let parser = is('h').many1_up_to(1);
 			let mut input = Input::new_from_chars("jklmno".chars(), None);
-			let mismatch = Mismatch::new('h', 'j');
-			assert_eq!(
-				parser(&mut input),
-				Err(Error::UnexpectedToken(
-					None,
-					Position::new(1, 1),
-					Some(mismatch)
-				))
-			);
+			let output = parser(&mut input);
+			let position = Position::new(1, 1);
+			assert_unexpected_error(output, position, "h", "j");
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}
 
@@ -837,7 +815,8 @@ mod tests {
 			let mut input = Input::new_from_chars("hhhhello".chars(), None);
 			let parser_up_to = many1_up_to(&parser, 3);
 			let output = parser_up_to(&mut input);
-			assert!(output.is_err());
+			let position = Position::new(1, 4);
+			assert_unexpected_error(output, position, "3", "4");
 		}
 
 		#[test]

--- a/src/combinators/many.rs
+++ b/src/combinators/many.rs
@@ -219,6 +219,18 @@ mod tests {
 		}
 
 		#[test]
+		fn partial_match_then_stop() {
+			let parser = is('#');
+			let mut input = Input::new_from_chars("#####Hello".chars(), None);
+			let parser_many0 = many0(&parser);
+			let output = parser_many0(&mut input).unwrap();
+			assert_eq!(output.len(), 5);
+			assert_eq!(input.consumed_count(), 5);
+			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+			assert_eq!(any()(&mut input), Ok('H'));
+		}
+
+		#[test]
 		fn non_consuming_parser_does_not_loop() {
 			let parser = success(1); // Non-consuming parser.
 			let mut input = Input::new_from_chars("hello".chars(), None);
@@ -346,7 +358,9 @@ mod tests {
 			let parser_many1 = many1(&parser);
 			let output = parser_many1(&mut input).unwrap();
 			assert_eq!(output, vec!['h', 'h']);
+			assert_eq!(input.consumed_count(), 2);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+			assert_eq!(any()(&mut input), Ok('j'));
 		}
 
 		#[test]

--- a/src/combinators/many.rs
+++ b/src/combinators/many.rs
@@ -219,7 +219,7 @@ where
 ///
 /// # Shortcut
 ///
-/// This combinator has a shortcut version: [`Parser::many0_up_to`].
+/// This combinator has a shortcut version: [`Parser::many1_up_to`].
 ///
 /// # Arguments
 ///

--- a/src/combinators/many.rs
+++ b/src/combinators/many.rs
@@ -272,24 +272,28 @@ where
 	many(parser, 1, Some(max_count))
 }
 
-fn many<P, IT, O>(parser: &P, min_count: usize, max_count: Option<usize>) -> impl Parser<IT, Vec<O>>
+fn many<P, IT, O>(
+	parser: &P,
+	min_match_count: usize,
+	max_match_count: Option<usize>,
+) -> impl Parser<IT, Vec<O>>
 where
 	P: Parser<IT, O>,
 	IT: InputToken,
 {
 	move |input| {
 		let mut matches: Vec<O> = Vec::new();
-		let mut total_count = 0;
-		let mut previous_count: Option<usize> = None;
+		let mut total_match_count = 0;
+		let mut previous_consumed_count = input.consumed_count();
 		loop {
 			let previous_position = input.position();
-			let parse_outcome = parser(input);
-			match (parse_outcome, max_count) {
-				(Ok(_), Some(max_count)) if max_count == total_count => {
-					// Matched too many times.
-					total_count += 1;
+			let outcome = parser(input);
+			match (outcome, max_match_count) {
+				// Matched too many times.
+				(Ok(_), Some(max_count)) if max_count == total_match_count => {
+					total_match_count += 1;
 					let expected = format!("at most {max_count} occurrences");
-					let found = format!("{total_count} occurrences");
+					let found = format!("{total_match_count} occurrences");
 					let mismatch = Mismatch::new(expected, found);
 					return Err(Error::UnexpectedToken(
 						input.source_name(),
@@ -297,24 +301,22 @@ where
 						Some(mismatch),
 					));
 				}
+				// Valid match.
 				(Ok(token), _) => {
-					// Valid match.
-					total_count += 1;
-					let new_count = input.consumed_count();
+					total_match_count += 1;
+					let consumed_count = input.consumed_count();
 					// Check if non-consuming parser. If so, it would cause an infinite loop.
-					if let Some(previous) = previous_count
-						&& previous == new_count
-					{
+					if previous_consumed_count == consumed_count {
 						return Err(Error::NonConsumingLoop(
 							input.source_name(),
 							input.position(),
 						));
 					}
 					matches.push(token);
-					previous_count = Some(new_count);
+					previous_consumed_count = consumed_count;
 				}
 				(Err(e), _) => {
-					return if total_count >= min_count {
+					return if total_match_count >= min_match_count {
 						Ok(matches)
 					} else {
 						Err(e)

--- a/src/combinators/many.rs
+++ b/src/combinators/many.rs
@@ -10,10 +10,15 @@ use crate::{Error, Input, InputToken, Parser};
 /// # Input consumption
 ///
 /// This parser consumes input if:
-/// - At least one occurrence of its argument parser succeeds, *and* its argument parser consumes
-///   input upon success.
+/// - At least one occurrence of its argument parser succeeds.
 /// - If its argument parser consumes input upon failure, independent of this combinator's outcome.
 ///
+/// # Error handling
+///
+/// This combinator fails with [`Error::NonConsumingLoop`] if the argument parser does not consume
+/// input upon success. This behavior is there to prevent an infinite loop caused by the input never
+/// being consumed.
+/// 
 /// # Look-ahead and backtracking
 ///
 /// This combinator doesn't perform any lookahead. It also never backtracks, given that it never
@@ -65,10 +70,15 @@ where
 /// # Input consumption
 ///
 /// This parser consumes input if:
-/// - At least one occurrence of its argument parser succeeds, *and* its argument parser consumes
-///   input upon success.
+/// - At least one occurrence of its argument parser succeeds.
 /// - If its argument parser consumes input upon failure, independent of this combinator's outcome.
 ///
+/// # Error handling
+///
+/// This combinator fails with [`Error::NonConsumingLoop`] if the argument parser does not consume
+/// input upon success. This behavior is there to prevent an infinite loop caused by the input never
+/// being consumed.
+/// 
 /// # Look-ahead and backtracking
 ///
 /// This combinator doesn't perform any lookahead and won't backtrack upon failure.

--- a/src/combinators/many.rs
+++ b/src/combinators/many.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Input, InputToken, Parser};
+use crate::{Error, Input, InputToken, Mismatch, Parser};
 
 /// Applies `parser` zero or more times.
 ///
@@ -18,7 +18,7 @@ use crate::{Error, Input, InputToken, Parser};
 /// This combinator fails with [`Error::NonConsumingLoop`] if the argument parser does not consume
 /// input upon success. This behavior is there to prevent an infinite loop caused by the input never
 /// being consumed.
-/// 
+///
 /// # Look-ahead and backtracking
 ///
 /// This combinator doesn't perform any lookahead. It also never backtracks, given that it never
@@ -57,7 +57,7 @@ where
 {
 	|input| {
 		let output: Vec<O> = Vec::new();
-		many(parser)(input, output)
+		many(parser, None)(input, output)
 	}
 }
 
@@ -78,7 +78,7 @@ where
 /// This combinator fails with [`Error::NonConsumingLoop`] if the argument parser does not consume
 /// input upon success. This behavior is there to prevent an infinite loop caused by the input never
 /// being consumed.
-/// 
+///
 /// # Look-ahead and backtracking
 ///
 /// This combinator doesn't perform any lookahead and won't backtrack upon failure.
@@ -116,22 +116,217 @@ where
 {
 	|input| {
 		let mut output: Vec<O> = Vec::new();
+		// Parse manually once to ensure that at least one occurrence of the parser succeeds.
 		match parser(input) {
 			Ok(token) => {
 				output.push(token);
-				many(parser)(input, output)
+				many(parser, None)(input, output)
 			}
 			Err(e) => Err(e),
 		}
 	}
 }
 
-fn many<P, IT, O>(parser: &P) -> impl Fn(&mut Input<IT>, Vec<O>) -> Result<Vec<O>, Error>
+/// Applies `parser` between 0 and a given number of times, ensuring that no more matches occur.
+///
+/// # Outcome
+///
+/// This combinator succeeds if the argument parser succeeds between 0 and up to (and including)
+/// `max_count` times. In that case, it returns a vector of matches of its argument parser.
+///
+/// It fails if the argument parser matches more than `max_count` times.
+///
+/// # Input consumption
+///
+/// This parser consumes input if:
+/// - At least one occurrence of its argument parser succeeds.
+/// - If its argument parser consumes input upon failure, independent of this combinator's outcome.
+///
+/// # Error handling
+///
+/// This combinator fails with [`Error::NonConsumingLoop`] if the argument parser does not consume
+/// input upon success. This behavior is there to prevent an infinite loop caused by the input never
+/// being consumed.
+///
+/// # Look-ahead and backtracking
+///
+/// This combinator doesn't perform any lookahead and won't backtrack upon failure.
+///
+/// # Shortcut
+///
+/// This combinator has a shortcut version: [`Parser::many0_up_to`].
+///
+/// # Arguments
+///
+/// - `parser`: The parser to be applied multiple times.
+/// - `max_count`: The (inclusive) maximum number of times that the argument parser should succeed.
+///
+/// # Examples
+///
+/// ```
+/// use yapcol::{Input, is, many0_up_to};
+///
+/// // Succeeds if the parser matches exactly `max_count` times.
+/// let parser = is('1');
+/// let mut input = Input::new_from_chars("112".chars(), None);
+/// let max_count = 2;
+/// assert_eq!(
+/// 	many0_up_to(&parser, max_count)(&mut input),
+/// 	Ok("11".chars().collect())
+/// );
+///
+/// // Succeeds if the parser matches less than `max_count` times.
+/// let parser = is('1');
+/// let mut input = Input::new_from_chars("112".chars(), None);
+/// let max_count = 5;
+/// assert_eq!(
+/// 	many0_up_to(&parser, max_count)(&mut input),
+/// 	Ok("11".chars().collect())
+/// );
+///
+/// // Fails if the parser matches more than `max_count` times.
+/// let parser = is('1');
+/// let mut input = Input::new_from_chars("1112".chars(), None);
+/// let max_count = 2;
+/// assert!(many0_up_to(&parser, max_count)(&mut input).is_err());
+///
+/// // Succeeds on empty input if `max_count` is 0.
+/// let mut input = Input::new_from_chars("".chars(), None);
+/// let max_count = 0;
+/// assert_eq!(many0_up_to(&parser, max_count)(&mut input), Ok(Vec::new()));
+/// ```
+pub fn many0_up_to<P, IT, O>(parser: &P, max_count: usize) -> impl Parser<IT, Vec<O>>
 where
 	P: Parser<IT, O>,
 	IT: InputToken,
 {
-	|input, mut output| {
+	move |input| {
+		let mut output: Vec<O> = Vec::new();
+		match parser(input) {
+			Ok(_) if max_count == 0 => {
+				let position = input.position();
+				let expected = "no occurrences".to_string();
+				let found = "at least one occurrence".to_string();
+				let mismatch = Mismatch::new(expected, found);
+				Err(Error::UnexpectedToken(
+					input.source_name(),
+					position,
+					Some(mismatch),
+				))
+			}
+			Ok(token) => {
+				output.push(token);
+				// One occurence has been consumed, so request `max_count - 1`.
+				many(parser, Some(max_count - 1))(input, output)
+			}
+			Err(_) => Ok(output),
+		}
+	}
+}
+
+/// Applies `parser` between 1 and a given number of times, ensuring that no more matches occur.
+///
+/// # Outcome
+///
+/// This combinator succeeds if the argument parser succeeds between 1 and up to (and including)
+/// `max_count` times. In that case, it returns a vector of matches of its argument parser.
+///
+/// It fails if the argument parser:
+/// - Never succeeds.
+/// - Matches more than `max_count` times.
+///
+/// # Input consumption
+///
+/// This parser consumes input if:
+/// - At least one occurrence of its argument parser succeeds.
+/// - If its argument parser consumes input upon failure, independent of this combinator's outcome.
+///
+/// # Error handling
+///
+/// This combinator fails with [`Error::NonConsumingLoop`] if the argument parser does not consume
+/// input upon success. This behavior is there to prevent an infinite loop caused by the input never
+/// being consumed.
+///
+/// # Look-ahead and backtracking
+///
+/// This combinator doesn't perform any lookahead and won't backtrack upon failure.
+///
+/// # Shortcut
+///
+/// This combinator has a shortcut version: [`Parser::many0_up_to`].
+///
+/// # Arguments
+///
+/// - `parser`: The parser to be applied multiple times.
+/// - `max_count`: The (inclusive) maximum number of times that the argument parser should succeed.
+///   Must be greater than 0, otherwise this function panics.
+///
+/// # Panics
+///
+/// This function panics if `max_count` is equal to 0. Check [`many0_up_to`] if you would like to
+/// cover this case.
+///
+/// # Examples
+///
+/// ```
+/// use yapcol::{Input, is, many1_up_to};
+///
+/// // Succeeds if the parser matches exactly `max_count` times.
+/// let parser = is('1');
+/// let mut input = Input::new_from_chars("112".chars(), None);
+/// let max_count = 2;
+/// assert_eq!(
+/// 	many1_up_to(&parser, max_count)(&mut input),
+/// 	Ok("11".chars().collect())
+/// );
+///
+/// // Succeeds if the parser matches less than `max_count` times.
+/// let parser = is('1');
+/// let mut input = Input::new_from_chars("112".chars(), None);
+/// let max_count = 5;
+/// assert_eq!(
+/// 	many1_up_to(&parser, max_count)(&mut input),
+/// 	Ok("11".chars().collect())
+/// );
+///
+/// // Fails if the parser matches more than `max_count` times.
+/// let parser = is('1');
+/// let mut input = Input::new_from_chars("1112".chars(), None);
+/// let max_count = 2;
+/// assert!(many1_up_to(&parser, max_count)(&mut input).is_err());
+/// ```
+pub fn many1_up_to<P, IT, O>(parser: &P, max_count: usize) -> impl Parser<IT, Vec<O>>
+where
+	P: Parser<IT, O>,
+	IT: InputToken,
+{
+	if max_count == 0 {
+		panic!("max_count must be greater than 0");
+	}
+	move |input| {
+		let mut output: Vec<O> = Vec::new();
+		// Parse manually once to ensure that at least one occurrence of the parser succeeds.
+		match parser(input) {
+			Ok(token) => {
+				output.push(token);
+				// One occurence has been consumed, so request `max_count - 1`.
+				many(parser, Some(max_count - 1))(input, output)
+			}
+			Err(e) => Err(e),
+		}
+	}
+}
+
+fn many<P, IT, O>(
+	parser: &P,
+	max_count: Option<usize>,
+) -> impl Fn(&mut Input<IT>, Vec<O>) -> Result<Vec<O>, Error>
+where
+	P: Parser<IT, O>,
+	IT: InputToken,
+{
+	move |input, mut output| {
+		let mut total_count = 0;
 		let mut previous_count: Option<usize> = None;
 		loop {
 			match parser(input) {
@@ -148,8 +343,28 @@ where
 					}
 					output.push(token);
 					previous_count = Some(new_count);
+					total_count += 1;
 				}
-				Err(_) => return Ok(output),
+				Err(_) => {
+					return match max_count {
+						None => Ok(output),
+						Some(max_count) => {
+							if total_count <= max_count {
+								Ok(output)
+							} else {
+								let position = input.position();
+								let expected = format!("at most {max_count} occurrences");
+								let found = format!("{total_count} occurrences");
+								let mismatch = Mismatch::new(expected, found);
+								Err(Error::UnexpectedToken(
+									input.source_name(),
+									position,
+									Some(mismatch),
+								))
+							}
+						}
+					};
+				}
 			}
 		}
 	}

--- a/src/combinators/many.rs
+++ b/src/combinators/many.rs
@@ -616,4 +616,235 @@ mod tests {
 			assert!(end_of_input()(&mut input).is_ok()); // Ensure that the input was consumed.
 		}
 	}
+
+	mod many0_up_to {
+		use crate::*;
+
+		#[test]
+		fn empty() {
+			let parser = is('h');
+			let mut input = Input::new_from_chars("".chars(), None);
+			let parser_up_to = many0_up_to(&parser, 1);
+			let output = parser_up_to(&mut input).unwrap();
+			assert_eq!(output.len(), 0);
+		}
+
+		#[test]
+		fn empty_shortcut() {
+			let parser = is('h').many0_up_to(1);
+			let mut input = Input::new_from_chars("".chars(), None);
+			let output = parser(&mut input).unwrap();
+			assert_eq!(output.len(), 0);
+		}
+
+		#[test]
+		fn no_match() {
+			let parser = is('h');
+			let mut input = Input::new_from_chars("jklmno".chars(), None);
+			let parser_up_to = many0_up_to(&parser, 1);
+			let output = parser_up_to(&mut input).unwrap();
+			assert_eq!(output.len(), 0);
+			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+		}
+
+		#[test]
+		fn no_match_shortcut() {
+			let parser = is('h').many0_up_to(1);
+			let mut input = Input::new_from_chars("jklmno".chars(), None);
+			let output = parser(&mut input).unwrap();
+			assert_eq!(output.len(), 0);
+			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+		}
+
+		#[test]
+		fn one_match() {
+			let parser = is('h');
+			let mut input = Input::new_from_chars("hello".chars(), None);
+			let parser_up_to = many0_up_to(&parser, 1);
+			let output = parser_up_to(&mut input).unwrap();
+			assert_eq!(output, vec!['h']);
+			assert_eq!(input.consumed_count(), 1);
+			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+			assert_eq!(any()(&mut input), Ok('e'));
+		}
+
+		#[test]
+		fn less_than_max_count() {
+			let parser = is('h');
+			let mut input = Input::new_from_chars("hhello".chars(), None);
+			let parser_up_to = many0_up_to(&parser, 3);
+			let output = parser_up_to(&mut input).unwrap();
+			assert_eq!(output, vec!['h', 'h']);
+			assert_eq!(input.consumed_count(), 2);
+			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+			assert_eq!(any()(&mut input), Ok('e'));
+		}
+
+		#[test]
+		fn equal_to_max_count() {
+			let parser = is('h');
+			let mut input = Input::new_from_chars("hhhello".chars(), None);
+			let parser_up_to = many0_up_to(&parser, 3);
+			let output = parser_up_to(&mut input).unwrap();
+			assert_eq!(output, vec!['h', 'h', 'h']);
+			assert_eq!(input.consumed_count(), 3);
+			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+			assert_eq!(any()(&mut input), Ok('e'));
+		}
+
+		#[test]
+		fn more_than_max_count() {
+			let parser = is('h');
+			let mut input = Input::new_from_chars("hhhhello".chars(), None);
+			let parser_up_to = many0_up_to(&parser, 3);
+			let output = parser_up_to(&mut input);
+			assert!(output.is_err());
+		}
+
+		#[test]
+		fn zero_empty() {
+			let parser = is('h');
+			let mut input = Input::new_from_chars("".chars(), None);
+			let parser_up_to = many0_up_to(&parser, 0);
+			let output = parser_up_to(&mut input).unwrap();
+			assert_eq!(output.len(), 0);
+			assert_eq!(input.consumed_count(), 0);
+		}
+
+		#[test]
+		fn zero_success() {
+			let parser = is('h');
+			let mut input = Input::new_from_chars("ello".chars(), None);
+			let parser_up_to = many0_up_to(&parser, 0);
+			let output = parser_up_to(&mut input).unwrap();
+			assert_eq!(output.len(), 0);
+			assert_eq!(input.consumed_count(), 0);
+			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+			assert_eq!(any()(&mut input), Ok('e'));
+		}
+
+		#[test]
+		fn zero_fail() {
+			let parser = is('h');
+			let mut input = Input::new_from_chars("hello".chars(), None);
+			let parser_up_to = many0_up_to(&parser, 0);
+			let output = parser_up_to(&mut input);
+			assert!(output.is_err());
+			assert_eq!(input.consumed_count(), 1);
+			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+			assert_eq!(any()(&mut input), Ok('e'));
+		}
+	}
+
+	mod many1_up_to {
+		use crate::combinators::many::many1_up_to;
+		use crate::input::Position;
+		use crate::*;
+
+		#[test]
+		fn empty() {
+			let parser = is('h');
+			let mut input = Input::new_from_chars("".chars(), None);
+			let parser_up_to = many1_up_to(&parser, 1);
+			assert_eq!(
+				parser_up_to(&mut input),
+				Err(Error::EndOfInput(Some(Box::new('h'))))
+			);
+		}
+
+		#[test]
+		fn empty_shortcut() {
+			let parser = is('h').many1_up_to(1);
+			let mut input = Input::new_from_chars("".chars(), None);
+			assert_eq!(
+				parser(&mut input),
+				Err(Error::EndOfInput(Some(Box::new('h'))))
+			);
+		}
+
+		#[test]
+		fn no_match() {
+			let parser = is('h');
+			let mut input = Input::new_from_chars("jklmno".chars(), None);
+			let parser_up_to = many1_up_to(&parser, 1);
+			let mismatch = Mismatch::new('h', 'j');
+			assert_eq!(
+				parser_up_to(&mut input),
+				Err(Error::UnexpectedToken(
+					None,
+					Position::new(1, 1),
+					Some(mismatch)
+				))
+			);
+			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+		}
+
+		#[test]
+		fn no_match_shortcut() {
+			let parser = is('h').many1_up_to(1);
+			let mut input = Input::new_from_chars("jklmno".chars(), None);
+			let mismatch = Mismatch::new('h', 'j');
+			assert_eq!(
+				parser(&mut input),
+				Err(Error::UnexpectedToken(
+					None,
+					Position::new(1, 1),
+					Some(mismatch)
+				))
+			);
+			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+		}
+
+		#[test]
+		fn one_match() {
+			let parser = is('h');
+			let mut input = Input::new_from_chars("hello".chars(), None);
+			let parser_up_to = many1_up_to(&parser, 1);
+			let output = parser_up_to(&mut input).unwrap();
+			assert_eq!(output, vec!['h']);
+			assert_eq!(input.consumed_count(), 1);
+			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+			assert_eq!(any()(&mut input), Ok('e'));
+		}
+
+		#[test]
+		fn less_than_max_count() {
+			let parser = is('h');
+			let mut input = Input::new_from_chars("hhello".chars(), None);
+			let parser_up_to = many1_up_to(&parser, 3);
+			let output = parser_up_to(&mut input).unwrap();
+			assert_eq!(output, vec!['h', 'h']);
+			assert_eq!(input.consumed_count(), 2);
+			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+			assert_eq!(any()(&mut input), Ok('e'));
+		}
+
+		#[test]
+		fn equal_to_max_count() {
+			let parser = is('h');
+			let mut input = Input::new_from_chars("hhhello".chars(), None);
+			let parser_up_to = many1_up_to(&parser, 3);
+			let output = parser_up_to(&mut input).unwrap();
+			assert_eq!(output, vec!['h', 'h', 'h']);
+			assert_eq!(input.consumed_count(), 3);
+			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+			assert_eq!(any()(&mut input), Ok('e'));
+		}
+
+		#[test]
+		fn more_than_max_count() {
+			let parser = is('h');
+			let mut input = Input::new_from_chars("hhhhello".chars(), None);
+			let parser_up_to = many1_up_to(&parser, 3);
+			let output = parser_up_to(&mut input);
+			assert!(output.is_err());
+		}
+
+		#[test]
+		#[should_panic]
+		fn zero_panics() {
+			let parser = is::<CharToken>('h');
+			let _ = many1_up_to(&parser, 0);
+		}
+	}
 }

--- a/src/combinators/many.rs
+++ b/src/combinators/many.rs
@@ -449,7 +449,7 @@ mod tests {
 			let mut input = Input::new_from_chars("#####Hello".chars(), None);
 			let parser_many0 = many0(&parser);
 			let output = parser_many0(&mut input).unwrap();
-			assert_eq!(output.len(), 5);
+			assert_eq!(output, "#####".chars().collect::<Vec<_>>());
 			assert_eq!(input.consumed_count(), 5);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 			assert_eq!(any()(&mut input), Ok('H'));
@@ -548,7 +548,7 @@ mod tests {
 			let mut input = Input::new_from_chars("hallo".chars(), None);
 			let parser_many1 = many1(&parser);
 			let output = parser_many1(&mut input).unwrap();
-			assert_eq!(output.len(), 1);
+			assert_eq!(output, vec!['h']);
 			assert_eq!(input.consumed_count(), 1);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}
@@ -558,7 +558,7 @@ mod tests {
 			let parser = is('h').many1();
 			let mut input = Input::new_from_chars("hallo".chars(), None);
 			let output = parser(&mut input).unwrap();
-			assert_eq!(output.len(), 1);
+			assert_eq!(output, vec!['h']);
 			assert_eq!(input.consumed_count(), 1);
 			assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
 		}

--- a/src/combinators/many_until.rs
+++ b/src/combinators/many_until.rs
@@ -11,11 +11,17 @@ use crate::{Error, InputToken, Parser};
 /// This parser consumes input if:
 /// - It succeeds, and:
 ///   - Its `end` argument parser consumes upon success, or;
-///   - Its `parser` argument consumes upon success, *and* it was applied at least once.
+///   - Its `parser` argument was applied at least once.
 /// - It fails, and:
 ///   - Its `end` argument parser consumes upon failure, or;
 ///   - Its `parser` argument consumes upon failure, *and* it was applied at least once.
 ///
+/// # Error handling
+///
+/// This combinator fails with [`Error::NonConsumingLoop`] if the argument parser does not consume
+/// input upon success. This behavior is there to prevent an infinite loop caused by the input never
+/// being consumed.
+/// 
 /// # Look-ahead and backtracking
 ///
 /// This combinator doesn't perform any lookahead and won't backtrack upon failure.

--- a/src/combinators/many_until.rs
+++ b/src/combinators/many_until.rs
@@ -21,7 +21,7 @@ use crate::{Error, InputToken, Parser};
 /// This combinator fails with [`Error::NonConsumingLoop`] if the argument parser does not consume
 /// input upon success. This behavior is there to prevent an infinite loop caused by the input never
 /// being consumed.
-/// 
+///
 /// # Look-ahead and backtracking
 ///
 /// This combinator doesn't perform any lookahead and won't backtrack upon failure.

--- a/src/combinators/mod.rs
+++ b/src/combinators/mod.rs
@@ -28,7 +28,7 @@ pub use either::either;
 pub use end_of_input::end_of_input;
 pub use is::is;
 pub use look_ahead::look_ahead;
-pub use many::{many0, many1};
+pub use many::{many0, many0_up_to, many1, many1_up_to};
 pub use many_until::many_until;
 pub use maybe::maybe;
 pub use not_followed_by::not_followed_by;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -327,6 +327,22 @@ where
 	{
 		move |input| count(&self, c)(input)
 	}
+
+	// A shortcut for the [`many0_up_to`] combinator
+	fn many0_up_to(self, max_count: usize) -> impl Parser<IT, Vec<O>>
+	where
+		Self: Sized,
+	{
+		move |input| many0_up_to(&self, max_count)(input)
+	}
+
+	// A shortcut for the [`many1_up_to`] combinator
+	fn many1_up_to(self, max_count: usize) -> impl Parser<IT, Vec<O>>
+	where
+		Self: Sized,
+	{
+		move |input| many1_up_to(&self, max_count)(input)
+	}
 }
 
 impl<IT, O, X> Parser<IT, O> for X


### PR DESCRIPTION
# Overview
This version introduces two new repetition combinators: `many0_up_to` and `many1_up_to`.

# New Features
- Add two new parser combinators that limit how many times a parser can be applied repeatedly, making it easy to parse bounded sequences:
  - `many0_up_to`: Applies a parser zero or more times, up to (and including) a given `max_count`. Fails if the argument parser matches more than `max_count` times.
  - `many1_up_to`: Applies a parser between 1 and `max_count` times (inclusive). Fails if the parser matches more than `max_count` times or doesn't match at least once.
- Add unit tests and `Parser` shortcut methods for the new combinators.