### PR TITLE
Add `many_at_least_discard` combinator

### DIFF
--- a/src/combinators/many/many_at_least_discard.rs
+++ b/src/combinators/many/many_at_least_discard.rs
@@ -1,0 +1,155 @@
+use super::core::{ManyOutput, many_no_end};
+use crate::{InputToken, Parser};
+
+/// Applies `parser` at least a given number of times (and possibly more), without collecting
+/// matches.
+///
+/// # Outcome
+///
+/// This combinator succeeds if the argument parser succeeds at least `min_count` times.
+///
+/// It fails if the argument parser matches fewer than `min_count` times.
+///
+/// # Input consumption
+///
+/// This parser consumes input if:
+/// - At least one occurrence of its argument parser succeeds.
+/// - If its argument parser consumes input upon failure, independent of this combinator's outcome.
+///
+/// # Error handling
+///
+/// This combinator fails with [`crate::Error::NonConsumingLoop`] if the argument parser does not
+/// consume input upon success. This behavior is there to prevent an infinite loop caused by the
+/// input never being consumed.
+///
+/// # Look-ahead and backtracking
+///
+/// This combinator doesn't perform any lookahead and won't backtrack upon failure.
+///
+/// # Shortcut
+///
+/// This combinator has a shortcut version: [`Parser::many_at_least_discard`].
+///
+/// # Arguments
+///
+/// - `parser`: The parser to be applied multiple times.
+/// - `min_count`: The minimum number of times that the argument parser should succeed.
+///
+/// # Examples
+///
+/// ```
+/// use yapcol::{Input, is, many_at_least_discard};
+///
+/// // Succeeds if the parser matches exactly `min_count` times.
+/// let parser = is('1');
+/// let mut input = Input::new_from_chars("112".chars(), None);
+/// let min_count = 2;
+/// assert_eq!(many_at_least_discard(&parser, min_count)(&mut input), Ok(2));
+///
+/// // Succeeds if the parser matches more than `min_count` times.
+/// let parser = is('1');
+/// let mut input = Input::new_from_chars("1112".chars(), None);
+/// let min_count = 2;
+/// assert_eq!(many_at_least_discard(&parser, min_count)(&mut input), Ok(3));
+///
+/// // Fails if the parser matches more than `max_count` times.
+/// let parser = is('1');
+/// let mut input = Input::new_from_chars("1".chars(), None);
+/// let max_count = 2;
+/// assert!(many_at_least_discard(&parser, max_count)(&mut input).is_err());
+/// ```
+pub fn many_at_least_discard<P, IT, O>(parser: &P, min_count: usize) -> impl Parser<IT, usize>
+where
+	P: Parser<IT, O>,
+	IT: InputToken,
+{
+	move |input| match many_no_end(parser, min_count, None, false)(input) {
+		Ok(ManyOutput::Matches(_)) => panic!("Expected Count, but got Matches."),
+		Ok(ManyOutput::Count(count)) => Ok(count),
+		Err(e) => Err(e),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::combinators::many::test_utils::assert_unexpected_error;
+	use crate::input::Position;
+	use crate::*;
+
+	#[test]
+	fn empty() {
+		let parser = is('h');
+		let mut input = Input::new_from_chars("".chars(), None);
+		let parser_up_to = many_at_least_discard(&parser, 1);
+		assert_eq!(
+			parser_up_to(&mut input),
+			Err(Error::EndOfInput(Some(Box::new('h'))))
+		);
+	}
+
+	#[test]
+	fn empty_shortcut() {
+		let parser = is('h').many_at_least_discard(1);
+		let mut input = Input::new_from_chars("".chars(), None);
+		assert_eq!(
+			parser(&mut input),
+			Err(Error::EndOfInput(Some(Box::new('h'))))
+		);
+	}
+
+	#[test]
+	fn no_match() {
+		let parser = is('h');
+		let mut input = Input::new_from_chars("jklmno".chars(), None);
+		let parser_up_to = many_at_least_discard(&parser, 1);
+		let output = parser_up_to(&mut input);
+		let position = Position::new(1, 1);
+		assert_unexpected_error(output, position, "h", "j");
+		assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+	}
+
+	#[test]
+	fn no_match_shortcut() {
+		let parser = is('h').many_at_least_discard(1);
+		let mut input = Input::new_from_chars("jklmno".chars(), None);
+		let output = parser(&mut input);
+		let position = Position::new(1, 1);
+		assert_unexpected_error(output, position, "h", "j");
+		assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+	}
+
+	#[test]
+	fn exact_count_succeeds() {
+		let parser = is('h');
+		let mut input = Input::new_from_chars("hello".chars(), None);
+		let parser_up_to = many_at_least_discard(&parser, 1);
+		let output = parser_up_to(&mut input).unwrap();
+		assert_eq!(output, 1);
+		assert_eq!(input.consumed_count(), 1);
+		assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+		assert_eq!(any()(&mut input), Ok('e'));
+	}
+
+	#[test]
+	fn more_than_count_succeeds() {
+		let parser = is('h');
+		let mut input = Input::new_from_chars("hhhello".chars(), None);
+		let parser_up_to = many_at_least_discard(&parser, 2);
+		let output = parser_up_to(&mut input).unwrap();
+		assert_eq!(output, 3);
+		assert_eq!(input.consumed_count(), 3);
+		assert!(end_of_input()(&mut input).is_err()); // Ensure that the input was NOT consumed.
+		assert_eq!(any()(&mut input), Ok('e'));
+	}
+
+	#[test]
+	fn less_than_min_count_fails() {
+		let parser = is('h');
+		let mut input = Input::new_from_chars("hhello".chars(), None);
+		let parser_up_to = many_at_least_discard(&parser, 3);
+		let output = parser_up_to(&mut input);
+		let position = Position::new(1, 3);
+		assert_unexpected_error(output, position, "h", "e");
+	}
+}

--- a/src/combinators/many/mod.rs
+++ b/src/combinators/many/mod.rs
@@ -7,10 +7,12 @@ mod many1;
 mod many1_discard;
 mod many1_up_to;
 mod many1_up_to_discard;
+mod many_at_least_discard;
 mod many_until;
 #[cfg(test)]
 mod test_utils;
 
+pub use many_at_least_discard::many_at_least_discard;
 pub use many_until::many_until;
 pub use many0::many0;
 pub use many0_discard::many0_discard;

--- a/src/combinators/mod.rs
+++ b/src/combinators/mod.rs
@@ -28,8 +28,8 @@ pub use end_of_input::end_of_input;
 pub use is::is;
 pub use look_ahead::look_ahead;
 pub use many::{
-	many_until, many0, many0_discard, many0_up_to, many0_up_to_discard, many1, many1_discard,
-	many1_up_to, many1_up_to_discard,
+	many_at_least_discard, many_until, many0, many0_discard, many0_up_to, many0_up_to_discard,
+	many1, many1_discard, many1_up_to, many1_up_to_discard,
 };
 pub use maybe::maybe;
 pub use not_followed_by::not_followed_by;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -387,6 +387,14 @@ where
 		move |input| many1_up_to_discard(&self, max_count)(input)
 	}
 
+	/// A shortcut for the [`many_at_least_discard`] combinator.
+	fn many_at_least_discard(self, min_count: usize) -> impl Parser<IT, usize>
+	where
+		Self: Sized,
+	{
+		move |input| many_at_least_discard(&self, min_count)(input)
+	}
+
 	/// A shortcut for the [`between`] combinator where the callee parser is the one in between.
 	fn between<PO, PC, OO, OC>(self, open: &PO, close: &PC) -> impl Parser<IT, O>
 	where


### PR DESCRIPTION
This PR adds the `many_at_least_discard` combinator. It matches at least `min-count` times (and possibly more) without collecting the matches.