### PR TITLE
Release 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yapcol"
 description = "Yet Another Parser Combinator Library - YAPCoL"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "MIT"
 authors = ["Matheus Amazonas"]

--- a/examples/evaluate_expression_string.rs
+++ b/examples/evaluate_expression_string.rs
@@ -100,8 +100,8 @@ fn main() {
 			Ok(_) => {
 				let mut input = Input::new_from_chars(input.chars(), Some("stdin".to_string()));
 				match parse_expression().exhaustive()(&mut input) {
-					Ok(e) => println!("Success: {:?}", evaluate(e)),
-					Err(e) => println!("Failed to parse expression: {e}"),
+					Ok(expression) => println!("Success: {:?}", evaluate(expression)),
+					Err(error) => println!("Failed to parse expression: {error}"),
 				}
 			}
 			Err(_) => println!("Failed to read input."),

--- a/examples/evaluate_expression_token.rs
+++ b/examples/evaluate_expression_token.rs
@@ -172,11 +172,11 @@ fn main() {
 					Ok(tokens) => {
 						let mut input = Input::new_from_tokens(tokens, Some("stdin".to_string()));
 						match parse_expression().exhaustive()(&mut input) {
-							Ok(e) => println!("Success: {:?}", evaluate(e)),
-							Err(e) => println!("Failed to parse expression: {e}"),
+							Ok(expression) => println!("Success: {:?}", evaluate(expression)),
+							Err(error) => println!("Failed to parse expression: {error}"),
 						}
 					}
-					Err(e) => println!("Failed to tokenize: {e}"),
+					Err(error) => println!("Failed to tokenize: {error}"),
 				}
 			}
 			Err(_) => println!("Failed to read input."),

--- a/src/combinators/attempt.rs
+++ b/src/combinators/attempt.rs
@@ -34,7 +34,7 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser`: The parser to attempt.
+/// - `parser`: the parser to attempt.
 ///
 /// # Examples
 ///

--- a/src/combinators/between.rs
+++ b/src/combinators/between.rs
@@ -23,9 +23,9 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `open`: The parser that "opens" the between.
-/// - `parser`: The parser that goes between `open` and `close`, whose content we're interested in.
-/// - `close`: The parser that "closes" the between.
+/// - `open`: the parser that "opens" the between.
+/// - `parser`: the parser that goes between `open` and `close`, whose content we're interested in.
+/// - `close`: the parser that "closes" the between.
 ///
 /// # Examples
 ///

--- a/src/combinators/chain.rs
+++ b/src/combinators/chain.rs
@@ -20,9 +20,9 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `operand_parser`: Parses operands that will be combined into a final value, in a
+/// - `operand_parser`: parses operands that will be combined into a final value, in a
 ///   left-associative manner.
-/// - `operator_parser`: Operator's parser, which consumes input and returns a function that
+/// - `operator_parser`: operator's parser, which consumes input and returns a function that
 ///   combines output values into one.
 ///
 /// # Examples
@@ -81,9 +81,9 @@ where
 ///
 /// # Arguments
 ///
-/// - `operand_parser`: Parses operands that will be combined into a final value, in a
+/// - `operand_parser`: parses operands that will be combined into a final value, in a
 ///   right-associative manner.
-/// - `operator_parser`: Operator's parser, which consumes input and returns a function that
+/// - `operator_parser`: operator's parser, which consumes input and returns a function that
 ///   combines output values into one.
 ///
 /// # Examples

--- a/src/combinators/choice.rs
+++ b/src/combinators/choice.rs
@@ -25,7 +25,7 @@ use crate::{Error, InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parsers`: An iterator that contains all parsers to attempt until a success.
+/// - `parsers`: an iterator that contains all parsers to attempt until a success.
 ///
 /// # Examples
 ///

--- a/src/combinators/either.rs
+++ b/src/combinators/either.rs
@@ -28,8 +28,8 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser1`: The first parser to try.
-/// - `parser2`: The fallback parser, applied only if `parser1` fails without consuming input.
+/// - `parser1`: the first parser to try.
+/// - `parser2`: the fallback parser, applied only if `parser1` fails without consuming input.
 ///
 /// # Examples
 ///

--- a/src/combinators/is.rs
+++ b/src/combinators/is.rs
@@ -17,7 +17,7 @@ use crate::{Error, InputToken, Mismatch, Parser};
 ///
 /// # Arguments
 ///
-/// - `token`: A reference to the token to match against.
+/// - `token`: a reference to the token to match against.
 ///
 /// # Examples
 ///

--- a/src/combinators/look_ahead.rs
+++ b/src/combinators/look_ahead.rs
@@ -17,7 +17,7 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser`: The parser to look ahead.
+/// - `parser`: the parser to look ahead.
 ///
 /// # Examples
 ///

--- a/src/combinators/maybe.rs
+++ b/src/combinators/maybe.rs
@@ -27,7 +27,7 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser`: The parser to make optional.
+/// - `parser`: the parser to make optional.
 ///
 /// # Examples
 ///

--- a/src/combinators/mod.rs
+++ b/src/combinators/mod.rs
@@ -29,8 +29,8 @@ pub use maybe::maybe;
 pub use not_followed_by::not_followed_by;
 pub use repetition::{
 	at_least, at_least_collect, count, count_collect, many, many_collect, many_until,
-	many_until_collect, once_or_more, once_or_more_collect, once_up_to, once_up_to_collect, up_to,
-	up_to_collect,
+	many_until_collect, once_or_more, once_or_more_collect, once_or_more_until, once_up_to,
+	once_up_to_collect, up_to, up_to_collect,
 };
 pub use satisfy::satisfy;
 pub use separated_by::{separated_by0, separated_by1};

--- a/src/combinators/mod.rs
+++ b/src/combinators/mod.rs
@@ -29,8 +29,8 @@ pub use maybe::maybe;
 pub use not_followed_by::not_followed_by;
 pub use repetition::{
 	at_least, at_least_collect, count, count_collect, many, many_collect, many_until,
-	many_until_collect, once_or_more, once_or_more_collect, once_or_more_until, once_up_to,
-	once_up_to_collect, up_to, up_to_collect,
+	many_until_collect, once_or_more, once_or_more_collect, once_or_more_until,
+	once_or_more_until_collect, once_up_to, once_up_to_collect, up_to, up_to_collect,
 };
 pub use satisfy::satisfy;
 pub use separated_by::{separated_by0, separated_by1};

--- a/src/combinators/repetition/at_least.rs
+++ b/src/combinators/repetition/at_least.rs
@@ -33,8 +33,8 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser`: The parser to be applied multiple times.
-/// - `min_count`: The minimum number of times that the argument parser should succeed.
+/// - `parser`: the parser to be applied multiple times.
+/// - `min_count`: the minimum number of times that the argument parser should succeed.
 ///
 /// # Examples
 ///

--- a/src/combinators/repetition/at_least_collect.rs
+++ b/src/combinators/repetition/at_least_collect.rs
@@ -32,8 +32,8 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser`: The parser to be applied multiple times.
-/// - `min_count`: The minimum number of times that the argument parser should succeed.
+/// - `parser`: the parser to be applied multiple times.
+/// - `min_count`: the minimum number of times that the argument parser should succeed.
 ///
 /// # Examples
 ///

--- a/src/combinators/repetition/core.rs
+++ b/src/combinators/repetition/core.rs
@@ -134,7 +134,18 @@ where
 				(Err(e), _) => return Err(e),
 			}
 		}
-		Ok(accumulator)
+		if total_match_count >= min_match_count {
+			Ok(accumulator)
+		} else {
+			let expected = format!("at least {min_match_count} occurrences");
+			let found = format!("{total_match_count} occurrences");
+			let mismatch = Mismatch::new(expected, found);
+			Err(Error::UnexpectedToken(
+				input.source_name(),
+				input.position(),
+				Some(mismatch)
+			))
+		}
 	}
 }
 

--- a/src/combinators/repetition/core.rs
+++ b/src/combinators/repetition/core.rs
@@ -143,7 +143,7 @@ where
 			Err(Error::UnexpectedToken(
 				input.source_name(),
 				input.position(),
-				Some(mismatch)
+				Some(mismatch),
 			))
 		}
 	}

--- a/src/combinators/repetition/count.rs
+++ b/src/combinators/repetition/count.rs
@@ -32,8 +32,8 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser`: The parser to apply repeatedly.
-/// - `count`: The exact number of times to apply the parser.
+/// - `parser`: the parser to apply repeatedly.
+/// - `count`: the exact number of times to apply the parser.
 ///
 /// # Examples
 ///

--- a/src/combinators/repetition/count_collect.rs
+++ b/src/combinators/repetition/count_collect.rs
@@ -36,8 +36,8 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser`: The parser to apply repeatedly.
-/// - `count`: The exact number of times to apply the parser.
+/// - `parser`: the parser to apply repeatedly.
+/// - `count`: the exact number of times to apply the parser.
 ///
 /// # Examples
 ///

--- a/src/combinators/repetition/many.rs
+++ b/src/combinators/repetition/many.rs
@@ -32,7 +32,7 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser`: The parser to possibly be applied many times.
+/// - `parser`: the parser to possibly be applied many times.
 ///
 /// # Examples
 ///

--- a/src/combinators/repetition/many_collect.rs
+++ b/src/combinators/repetition/many_collect.rs
@@ -36,7 +36,7 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser`: The parser to possibly be applied many times.
+/// - `parser`: the parser to possibly be applied many times.
 ///
 /// # Examples
 ///

--- a/src/combinators/repetition/many_until.rs
+++ b/src/combinators/repetition/many_until.rs
@@ -13,7 +13,7 @@ use crate::{InputToken, Parser};
 /// This parser consumes input if:
 /// - It succeeds, and:
 ///   - Its `end` argument parser consumes upon success, or;
-///   - Its `parser` argument was applied at least once.
+///   - Its `parser` argument succeeded at least once.
 /// - It fails, and:
 ///   - Its `end` argument parser consumes upon failure, or;
 ///   - Its `parser` argument consumes upon failure, *and* it was applied at least once.

--- a/src/combinators/repetition/many_until.rs
+++ b/src/combinators/repetition/many_until.rs
@@ -30,7 +30,7 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser`: the parser for the elements to be collected until the end is reached.
+/// - `parser`: the parser to possibly be applied many times.
 /// - `end`: the parser that delimits the end.
 ///
 /// # Examples
@@ -67,7 +67,7 @@ mod tests {
 	use crate::*;
 
 	#[test]
-	fn empty() {
+	fn empty_fails() {
 		let any_parser = any();
 		let end_comment_parser = is('#');
 		let mut input = Input::new_from_chars("".chars(), None);
@@ -77,7 +77,7 @@ mod tests {
 	}
 
 	#[test]
-	fn success_none() {
+	fn no_matches_succeeds() {
 		let any_parser = any();
 		let end_comment_parser = is('#');
 		let mut input = Input::new_from_chars("#".chars(), None);
@@ -87,7 +87,7 @@ mod tests {
 	}
 
 	#[test]
-	fn success_multiple() {
+	fn multiple_matches_succeeds() {
 		let any_parser = any();
 		let end_comment_parser = is('#');
 		let mut input = Input::new_from_chars("123456#".chars(), None);
@@ -97,7 +97,7 @@ mod tests {
 	}
 
 	#[test]
-	fn fail() {
+	fn no_end_fails() {
 		let any_parser = is('x');
 		let end_comment_parser = is('#');
 		let mut input = Input::new_from_chars("xxxxxy".chars(), None);

--- a/src/combinators/repetition/many_until.rs
+++ b/src/combinators/repetition/many_until.rs
@@ -28,6 +28,10 @@ use crate::{InputToken, Parser};
 ///
 /// This combinator doesn't perform any lookahead and won't backtrack upon failure.
 ///
+/// # Shortcut
+///
+/// This combinator has a shortcut version: [`Parser::many_until`].
+///
 /// # Arguments
 ///
 /// - `parser`: the parser to possibly be applied many times.

--- a/src/combinators/repetition/many_until_collect.rs
+++ b/src/combinators/repetition/many_until_collect.rs
@@ -12,7 +12,7 @@ use crate::{InputToken, Parser};
 /// This parser consumes input if:
 /// - It succeeds, and:
 ///   - Its `end` argument parser consumes upon success, or;
-///   - Its `parser` argument was applied at least once.
+///   - Its `parser` argument succeeded at least once.
 /// - It fails, and:
 ///   - Its `end` argument parser consumes upon failure, or;
 ///   - Its `parser` argument consumes upon failure, *and* it was applied at least once.

--- a/src/combinators/repetition/many_until_collect.rs
+++ b/src/combinators/repetition/many_until_collect.rs
@@ -66,7 +66,7 @@ mod tests {
 	use crate::*;
 
 	#[test]
-	fn empty() {
+	fn empty_fails() {
 		let any_parser = any();
 		let end_comment_parser = is('#');
 		let mut input = Input::new_from_chars("".chars(), None);
@@ -76,7 +76,7 @@ mod tests {
 	}
 
 	#[test]
-	fn success_none() {
+	fn no_matches_succeeds() {
 		let any_parser = any();
 		let end_comment_parser = is('#');
 		let mut input = Input::new_from_chars("#".chars(), None);
@@ -86,7 +86,7 @@ mod tests {
 	}
 
 	#[test]
-	fn success_multiple() {
+	fn multiple_matches_succeeds() {
 		let any_parser = any();
 		let end_comment_parser = is('#');
 		let mut input = Input::new_from_chars("Hello world #".chars(), None);
@@ -96,7 +96,7 @@ mod tests {
 	}
 
 	#[test]
-	fn fail() {
+	fn no_end_fails() {
 		let any_parser = is('x');
 		let end_comment_parser = is('#');
 		let mut input = Input::new_from_chars("xxxxxy".chars(), None);

--- a/src/combinators/repetition/many_until_collect.rs
+++ b/src/combinators/repetition/many_until_collect.rs
@@ -27,6 +27,15 @@ use crate::{InputToken, Parser};
 ///
 /// This combinator doesn't perform any lookahead and won't backtrack upon failure.
 ///
+/// # Performance
+///
+/// This combinator stores all the matches it finds. If you're not interested in the matches, but
+/// instead in how many times it matched, consider using [`crate::many_until`].
+///
+/// # Shortcut
+///
+/// This combinator has a shortcut version: [`Parser::many_until_collect`].
+///
 /// # Arguments
 ///
 /// - `parser`: the parser for the elements to be collected until the end is reached.

--- a/src/combinators/repetition/mod.rs
+++ b/src/combinators/repetition/mod.rs
@@ -9,6 +9,7 @@ mod many_until;
 mod many_until_collect;
 mod once_or_more;
 mod once_or_more_collect;
+mod once_or_more_until;
 mod once_up_to;
 mod once_up_to_collect;
 #[cfg(test)]
@@ -26,6 +27,7 @@ pub use many_until::many_until;
 pub use many_until_collect::many_until_collect;
 pub use once_or_more::once_or_more;
 pub use once_or_more_collect::once_or_more_collect;
+pub use once_or_more_until::once_or_more_until;
 pub use once_up_to::once_up_to;
 pub use once_up_to_collect::once_up_to_collect;
 pub use up_to::up_to;

--- a/src/combinators/repetition/mod.rs
+++ b/src/combinators/repetition/mod.rs
@@ -10,6 +10,7 @@ mod many_until_collect;
 mod once_or_more;
 mod once_or_more_collect;
 mod once_or_more_until;
+mod once_or_more_until_collect;
 mod once_up_to;
 mod once_up_to_collect;
 #[cfg(test)]
@@ -28,6 +29,7 @@ pub use many_until_collect::many_until_collect;
 pub use once_or_more::once_or_more;
 pub use once_or_more_collect::once_or_more_collect;
 pub use once_or_more_until::once_or_more_until;
+pub use once_or_more_until_collect::once_or_more_until_collect;
 pub use once_up_to::once_up_to;
 pub use once_up_to_collect::once_up_to_collect;
 pub use up_to::up_to;

--- a/src/combinators/repetition/once_or_more.rs
+++ b/src/combinators/repetition/once_or_more.rs
@@ -30,7 +30,7 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser`: The parser to be applied many times.
+/// - `parser`: the parser to be applied one or more times.
 ///
 /// # Examples
 ///

--- a/src/combinators/repetition/once_or_more_collect.rs
+++ b/src/combinators/repetition/once_or_more_collect.rs
@@ -34,7 +34,7 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser`: The parser to be applied many times.
+/// - `parser`: the parser to be applied one or more times.
 ///
 /// # Examples
 ///

--- a/src/combinators/repetition/once_or_more_until.rs
+++ b/src/combinators/repetition/once_or_more_until.rs
@@ -1,0 +1,146 @@
+use super::core::{CountAccumulator, RepetitionAccumulator, repeat_with_end};
+use crate::{InputToken, Parser};
+
+/// Applies `parser` one or more times, until `end` succeeds.
+///
+/// # Outcome
+///
+/// If successful, unlike [`crate::once_or_more_until_collect`], this combinator doesn't return
+/// its matches, but just how many times it matched.
+///
+/// # Input consumption
+///
+/// This parser consumes input if:
+/// - It succeeds, and:
+///   - Its `end` argument parser consumes upon success, or;
+///   - Its `parser` argument succeeded at least once.
+/// - It fails, and:
+///   - Its `end` argument parser consumes upon failure, or;
+///   - Its `parser` argument consumes upon failure, *and* it was applied at least once.
+///
+/// # Error handling
+///
+/// This combinator fails with [`crate::Error::NonConsumingLoop`] if the argument parser does not
+/// consume input upon success. This behavior is there to prevent an infinite loop caused by the
+/// input never being consumed.
+///
+/// # Look-ahead and backtracking
+///
+/// This combinator doesn't perform any lookahead and won't backtrack upon failure.
+///
+/// # Shortcut
+///
+/// This combinator has a shortcut version: [`Parser::once_or_more_until`].
+/// 
+/// # Arguments
+///
+/// - `parser`: the parser to be applied one or more times.
+/// - `end`: the parser that delimits the end.
+///
+/// # Examples
+///
+/// ```
+/// use yapcol::{Error, Input, any, is, once_or_more_until};
+///
+/// let comments_parser = |input: &mut Input<_>| {
+/// 	let open = is('#');
+/// 	let close = is('$');
+/// 	let any = any();
+/// 	open(input)?;
+/// 	once_or_more_until(&any, &close)(input)
+/// };
+/// // Success if there is at least one character before the end.
+/// let mut input = Input::new_from_chars("#12345$".chars(), None);
+/// let output = comments_parser(&mut input);
+/// assert_eq!(output, Ok(5));
+///
+/// // Fails if there is no character before the end.
+/// let mut input = Input::new_from_chars("#$".chars(), None);
+/// let output = comments_parser(&mut input);
+/// assert!(output.is_err());
+/// ```
+pub fn once_or_more_until<P, PE, IT, O, OE>(parser: &P, end: &PE) -> impl Parser<IT, usize>
+where
+	P: Parser<IT, O>,
+	PE: Parser<IT, OE>,
+	IT: InputToken,
+{
+	move |input| {
+		let accumulator: CountAccumulator<O> = repeat_with_end(parser, 1, None, end)(input)?;
+		Ok(accumulator.value())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::input::Position;
+	use crate::*;
+
+	#[test]
+	fn empty_fails() {
+		let any_parser = any();
+		let end_comment_parser = is('#');
+		let mut input = Input::new_from_chars("".chars(), None);
+		let not_followed_parser = once_or_more_until(&any_parser, &end_comment_parser);
+		let output = not_followed_parser(&mut input);
+		assert_eq!(output, Err(Error::EndOfInput(None)));
+	}
+
+	#[test]
+	fn no_match_fails() {
+		let any_parser = any();
+		let end_comment_parser = is('#');
+		let mut input = Input::new_from_chars("#".chars(), None);
+		let not_followed_parser = once_or_more_until(&any_parser, &end_comment_parser);
+		let output = not_followed_parser(&mut input);
+		let mismatch = Mismatch::new("at least 1 occurrences", "0 occurrences");
+		assert_eq!(
+			output,
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 1),
+				Some(mismatch)
+			))
+		);
+	}
+
+	#[test]
+	fn multiple_matches_succeeds() {
+		let any_parser = any();
+		let end_comment_parser = is('#');
+		let mut input = Input::new_from_chars("123456#".chars(), None);
+		let many_parser = once_or_more_until(&any_parser, &end_comment_parser);
+		let output = many_parser(&mut input).unwrap();
+		assert_eq!(output, 6);
+	}
+
+	#[test]
+	fn no_end_fails() {
+		let any_parser = is('x');
+		let end_comment_parser = is('#');
+		let mut input = Input::new_from_chars("xxxxxy".chars(), None);
+		let many_parser = once_or_more_until(&any_parser, &end_comment_parser);
+		let output = many_parser(&mut input);
+		let mismatch = Mismatch::new('x', 'y');
+		assert_eq!(
+			output,
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 6),
+				Some(mismatch)
+			))
+		);
+		assert_eq!(any()(&mut input), Ok('y')); // Input was consumed while looking for the end.
+	}
+
+	#[test]
+	fn non_consuming_parser_does_not_loop() {
+		let non_consuming = success(1); // Non-consuming parser.
+		let mut input = Input::new_from_chars("hello#".chars(), None);
+		let end_parser = is('#');
+		let parser = once_or_more_until(&non_consuming, &end_parser);
+		let output = parser(&mut input);
+		let position = Position::new(1, 1);
+		assert_eq!(output, Err(Error::NonConsumingLoop(None, position)));
+	}
+}

--- a/src/combinators/repetition/once_or_more_until_collect.rs
+++ b/src/combinators/repetition/once_or_more_until_collect.rs
@@ -1,12 +1,11 @@
-use super::core::{CountAccumulator, RepetitionAccumulator, repeat_with_end};
+use super::core::{MatchesAccumulator, RepetitionAccumulator, repeat_with_end};
 use crate::{InputToken, Parser};
 
-/// Applies `parser` one or more times, until `end` succeeds.
+/// Applies `parser` one or more times, until `end` succeeds, collecting all the matches.
 ///
 /// # Outcome
 ///
-/// If successful, unlike [`crate::once_or_more_until_collect`], this combinator doesn't return
-/// its matches, but just how many times it matched.
+/// If it succeeds, this combinator returns a vector of matches of its `parser` argument.
 ///
 /// # Input consumption
 ///
@@ -28,9 +27,14 @@ use crate::{InputToken, Parser};
 ///
 /// This combinator doesn't perform any lookahead and won't backtrack upon failure.
 ///
+/// # Performance
+///
+/// This combinator stores all the matches it finds. If you're not interested in the matches, but
+/// instead in how many times it matched, consider using [`crate::once_or_more_until`].
+///
 /// # Shortcut
 ///
-/// This combinator has a shortcut version: [`Parser::once_or_more_until`].
+/// This combinator has a shortcut version: [`Parser::once_or_more_until_collect`].
 ///
 /// # Arguments
 ///
@@ -40,33 +44,33 @@ use crate::{InputToken, Parser};
 /// # Examples
 ///
 /// ```
-/// use yapcol::{Error, Input, any, is, once_or_more_until};
+/// use yapcol::{Error, Input, any, is, once_or_more_until_collect};
 ///
 /// let comments_parser = |input: &mut Input<_>| {
 /// 	let open = is('#');
 /// 	let close = is('$');
 /// 	let any = any();
 /// 	open(input)?;
-/// 	once_or_more_until(&any, &close)(input)
+/// 	once_or_more_until_collect(&any, &close)(input)
 /// };
 /// // Success if there is at least one character before the end.
 /// let mut input = Input::new_from_chars("#12345$".chars(), None);
 /// let output = comments_parser(&mut input);
-/// assert_eq!(output, Ok(5));
+/// assert_eq!(output, Ok(vec!['1', '2', '3', '4', '5']));
 ///
 /// // Fails if there is no character before the end.
 /// let mut input = Input::new_from_chars("#$".chars(), None);
 /// let output = comments_parser(&mut input);
 /// assert!(output.is_err());
 /// ```
-pub fn once_or_more_until<P, PE, IT, O, OE>(parser: &P, end: &PE) -> impl Parser<IT, usize>
+pub fn once_or_more_until_collect<P, PE, IT, O, OE>(parser: &P, end: &PE) -> impl Parser<IT, Vec<O>>
 where
 	P: Parser<IT, O>,
 	PE: Parser<IT, OE>,
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: CountAccumulator<O> = repeat_with_end(parser, 1, None, end)(input)?;
+		let accumulator: MatchesAccumulator<O> = repeat_with_end(parser, 1, None, end)(input)?;
 		Ok(accumulator.value())
 	}
 }
@@ -81,7 +85,7 @@ mod tests {
 		let any_parser = any();
 		let end_comment_parser = is('#');
 		let mut input = Input::new_from_chars("".chars(), None);
-		let not_followed_parser = once_or_more_until(&any_parser, &end_comment_parser);
+		let not_followed_parser = once_or_more_until_collect(&any_parser, &end_comment_parser);
 		let output = not_followed_parser(&mut input);
 		assert_eq!(output, Err(Error::EndOfInput(None)));
 	}
@@ -91,7 +95,7 @@ mod tests {
 		let any_parser = any();
 		let end_comment_parser = is('#');
 		let mut input = Input::new_from_chars("#".chars(), None);
-		let not_followed_parser = once_or_more_until(&any_parser, &end_comment_parser);
+		let not_followed_parser = once_or_more_until_collect(&any_parser, &end_comment_parser);
 		let output = not_followed_parser(&mut input);
 		let mismatch = Mismatch::new("at least 1 occurrences", "0 occurrences");
 		assert_eq!(
@@ -109,9 +113,9 @@ mod tests {
 		let any_parser = any();
 		let end_comment_parser = is('#');
 		let mut input = Input::new_from_chars("123456#".chars(), None);
-		let many_parser = once_or_more_until(&any_parser, &end_comment_parser);
+		let many_parser = once_or_more_until_collect(&any_parser, &end_comment_parser);
 		let output = many_parser(&mut input).unwrap();
-		assert_eq!(output, 6);
+		assert_eq!(output, vec!['1', '2', '3', '4', '5', '6']);
 	}
 
 	#[test]
@@ -119,7 +123,7 @@ mod tests {
 		let any_parser = is('x');
 		let end_comment_parser = is('#');
 		let mut input = Input::new_from_chars("xxxxxy".chars(), None);
-		let many_parser = once_or_more_until(&any_parser, &end_comment_parser);
+		let many_parser = once_or_more_until_collect(&any_parser, &end_comment_parser);
 		let output = many_parser(&mut input);
 		let mismatch = Mismatch::new('x', 'y');
 		assert_eq!(
@@ -138,7 +142,7 @@ mod tests {
 		let non_consuming = success(1); // Non-consuming parser.
 		let mut input = Input::new_from_chars("hello#".chars(), None);
 		let end_parser = is('#');
-		let parser = once_or_more_until(&non_consuming, &end_parser);
+		let parser = once_or_more_until_collect(&non_consuming, &end_parser);
 		let output = parser(&mut input);
 		let position = Position::new(1, 1);
 		assert_eq!(output, Err(Error::NonConsumingLoop(None, position)));

--- a/src/combinators/repetition/once_up_to.rs
+++ b/src/combinators/repetition/once_up_to.rs
@@ -33,8 +33,8 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser`: The parser to be applied multiple times.
-/// - `max_count`: The (inclusive) maximum number of times that the argument parser should succeed.
+/// - `parser`: the parser to be applied one or more times.
+/// - `max_count`: the (inclusive) maximum number of times that the argument parser should succeed.
 ///   Must be greater than 0, otherwise this function panics.
 ///
 /// # Panics

--- a/src/combinators/repetition/once_up_to_collect.rs
+++ b/src/combinators/repetition/once_up_to_collect.rs
@@ -40,8 +40,8 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser`: The parser to be applied multiple times.
-/// - `max_count`: The (inclusive) maximum number of times that the argument parser should succeed.
+/// - `parser`: the parser to be applied one or more times.
+/// - `max_count`: the (inclusive) maximum number of times that the argument parser should succeed.
 ///   Must be greater than 0, otherwise this function panics.
 ///
 /// # Panics

--- a/src/combinators/repetition/up_to.rs
+++ b/src/combinators/repetition/up_to.rs
@@ -33,8 +33,8 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser`: The parser to be applied multiple times.
-/// - `max_count`: The (inclusive) maximum number of times that the argument parser should succeed.
+/// - `parser`: the parser to be applied multiple times.
+/// - `max_count`: the (inclusive) maximum number of times that the argument parser should succeed.
 ///
 /// # Examples
 ///

--- a/src/combinators/repetition/up_to_collect.rs
+++ b/src/combinators/repetition/up_to_collect.rs
@@ -38,8 +38,8 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser`: The parser to be applied multiple times.
-/// - `max_count`: The (inclusive) maximum number of times that the argument parser should succeed.
+/// - `parser`: the parser to be applied multiple times.
+/// - `max_count`: the (inclusive) maximum number of times that the argument parser should succeed.
 ///
 /// # Examples
 ///

--- a/src/combinators/satisfy.rs
+++ b/src/combinators/satisfy.rs
@@ -17,7 +17,7 @@ use crate::{Error, InputToken, Mismatch, Parser};
 ///
 /// # Arguments
 ///
-/// - `f`: A predicate that takes a reference to a token and returns `Some` on success or
+/// - `f`: a predicate that takes a reference to a token and returns `Some` on success or
 ///   `None` on failure.
 ///
 /// # Examples

--- a/src/combinators/separated_by.rs
+++ b/src/combinators/separated_by.rs
@@ -23,8 +23,8 @@ use crate::{Error, Input, InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `parser`: The parser whose occurrences we're collecting.
-/// - `separator`: The separator parser, whose content we're not interested in.
+/// - `parser`: the parser whose occurrences we're collecting.
+/// - `separator`: the separator parser, whose content we're not interested in.
 ///
 /// # Examples
 ///
@@ -76,8 +76,8 @@ where
 ///
 /// # Arguments
 ///
-/// - `parser`: The parser whose occurrences we're collecting.
-/// - `separator`: The separator parser, whose content we're not interested in.
+/// - `parser`: the parser whose occurrences we're collecting.
+/// - `separator`: the separator parser, whose content we're not interested in.
 ///
 /// # Examples
 ///

--- a/src/combinators/separated_by.rs
+++ b/src/combinators/separated_by.rs
@@ -12,7 +12,7 @@ use crate::{Error, Input, InputToken, Parser};
 /// This parser consumes input if:
 /// - It succeeds, and:
 ///   - Its `parser` argument consumes upon success, or;
-///   - Its `separator` argument parser consumes upon success, *and* it was applied at least once.
+///   - Its `separator` argument parser consumes upon success, *and* it succeeded at least once.
 /// - It fails, and:
 ///   - Its `parser` argument consumes upon failure, or;
 ///   - Its `separator` argument parser consumes upon failure, *and* it was applied at least once.
@@ -65,7 +65,7 @@ where
 /// This parser consumes input if:
 /// - It succeeds, and:
 ///   - Its `parser` argument consumes upon success, or;
-///   - Its `separator` argument parser consumes upon success, *and* it was applied at least once.
+///   - Its `separator` argument parser consumes upon success, *and* it succeeded at least once.
 /// - It fails, and:
 ///   - Its `parser` argument consumes upon failure, or;
 ///   - Its `separator` argument parser consumes upon failure, *and* it was applied at least once.

--- a/src/combinators/success.rs
+++ b/src/combinators/success.rs
@@ -16,7 +16,7 @@ use crate::{InputToken, Parser};
 ///
 /// # Arguments
 ///
-/// - `success`: The value to return when the parser is applied.
+/// - `success`: the value to return when the parser is applied.
 ///
 /// # Examples
 ///

--- a/src/input/core.rs
+++ b/src/input/core.rs
@@ -14,7 +14,7 @@ use std::fmt::{Debug, Display};
 ///
 /// # Type Parameters
 ///
-/// - `Token`: The underlying token value type.
+/// - `Token`: the underlying token value type.
 pub trait InputToken: Clone {
 	/// The underlying token, without any extra parsing-related data.
 	type Token: PartialEq + Clone + Display + Debug;
@@ -82,8 +82,8 @@ where
 	///
 	/// # Arguments
 	///
-	/// - `source`: Any value that can be turned into an iterator of [`InputToken`] items.
-	/// - `source_name`: An optional name for the source (e.g. a file path), included in
+	/// - `source`: any value that can be turned into an iterator of [`InputToken`] items.
+	/// - `source_name`: an optional name for the source (e.g. a file path), included in
 	///   error messages.
 	pub fn new_from_tokens<S, I>(source: S, source_name: Option<String>) -> Input<'a, IT>
 	where
@@ -222,10 +222,10 @@ where
 	///
 	/// # Arguments
 	///
-	/// - `handler`: Handler used to stop the lookahead operation. This handler *must* belong to the
+	/// - `handler`: handler used to stop the lookahead operation. This handler *must* belong to the
 	///   latest lookahead operation, enforcing the lookahead rule that only the most recent
 	///   operation might be stopped. The function will panic if this invariant is not respected.
-	/// - `backtrack`: Whether the input should backtrack. If `true`, all tokens fetched during the
+	/// - `backtrack`: whether the input should backtrack. If `true`, all tokens fetched during the
 	///   lookahead operation will remain cached, and later fetching will return them. In order
 	///   words, it pretends that all the fetching that happened during the lookahead operation
 	///   did not happen. If `false`, it discards the tokens fetched during the lookahead

--- a/src/input/string.rs
+++ b/src/input/string.rs
@@ -115,8 +115,8 @@ impl<'a> StringInput<'a> {
 	///
 	/// # Arguments
 	///
-	/// - `chars`: Any value that can be turned into a `char` iterator, such as [`str::chars`].
-	/// - `source_name`: An optional name for the source (e.g. a file path), to be included in
+	/// - `chars`: any value that can be turned into a `char` iterator, such as [`str::chars`].
+	/// - `source_name`: an optional name for the source (e.g. a file path), to be included in
 	///   error messages.
 	///
 	/// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,11 @@
 //!
 //! # Core Concepts
 //!
-//! - [`Parser`]: The central trait of the crate. Any function that takes a mutable reference
+//! - [`Parser`]: the central trait of the crate. Any function that takes a mutable reference
 //!   to an [`Input`] and returns a `Result<Output, Error>` is a parser.
-//! - [`Input`]: A wrapper around an iterator that provides buffering, lookahead, and position
+//! - [`Input`]: a wrapper around an iterator that provides buffering, lookahead, and position
 //!   tracking capabilities.
-//! - Combinators: Functions that take one or more parsers and return a new, more complex
+//! - Combinators: functions that take one or more parsers and return a new, more complex
 //!   parser. Examples: [`is()`], [`many`], [`either()`], [`chain_left()`].
 //!
 //! # Features

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -41,8 +41,8 @@ use crate::input::{CharToken, Input, InputToken, StringInput};
 ///
 /// # Type Parameters
 ///
-/// - `IT`: The parser's input token, which implements the [`InputToken`] trait.
-/// - `O`: The type of the value produced by the parser on success.
+/// - `IT`: the parser's input token, which implements the [`InputToken`] trait.
+/// - `O`: the type of the value produced by the parser on success.
 ///
 /// # Examples
 ///
@@ -82,8 +82,8 @@ where
 	/// error messages.
 	///
 	/// # Parameters
-	/// - `self`: The current parser.
-	/// - `expectation`: The value to use as the new expectation in any error produced by the
+	/// - `self`: the current parser.
+	/// - `expectation`: the value to use as the new expectation in any error produced by the
 	///   current parser.
 	///
 	/// # Returns
@@ -133,8 +133,8 @@ where
 	/// Transforms the output of the current parser using the provided function.
 	///
 	/// # Parameters
-	/// - `self`: The current parser.
-	/// - `f`: A closure or function that maps the previous output of the parser to a new output
+	/// - `self`: the current parser.
+	/// - `f`: a closure or function that maps the previous output of the parser to a new output
 	///   type.
 	///
 	/// # Returns
@@ -173,8 +173,8 @@ where
 	/// previous one.
 	///
 	/// # Parameters
-	/// - `self`: The current parser.
-	/// - `f`: A closure or function that takes the output of the current parser and returns a new
+	/// - `self`: the current parser.
+	/// - `f`: a closure or function that takes the output of the current parser and returns a new
 	///   parser.
 	///
 	/// # Returns
@@ -216,8 +216,8 @@ where
 	/// caring about its value and then continue parsing with a second parser.
 	///
 	/// # Parameters
-	/// - `self`: The current parser whose output is discarded on success.
-	/// - `other`: The parser to run after `self` succeeds.
+	/// - `self`: the current parser whose output is discarded on success.
+	/// - `other`: the parser to run after `self` succeeds.
 	///
 	/// # Returns
 	/// A new parser that first runs `self`, discards its output, then runs `other` on the same
@@ -284,7 +284,7 @@ where
 	/// needed, but its side effect (consuming input) is.
 	///
 	/// # Parameters
-	/// - `self`: The current parser whose output is discarded on success.
+	/// - `self`: the current parser whose output is discarded on success.
 	///
 	/// # Returns
 	/// A new parser that runs the current parser, but returns `()` instead of the original output.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -446,6 +446,15 @@ where
 		move |input| once_or_more_until(&self, end)(input)
 	}
 
+	/// A shortcut for the [`once_or_more_until_collect`] combinator.
+	fn once_or_more_until_collect<PE, OE>(self, end: &PE) -> impl Parser<IT, Vec<O>>
+	where
+		Self: Sized,
+		PE: Parser<IT, OE>,
+	{
+		move |input| once_or_more_until_collect(&self, end)(input)
+	}
+
 	/// A shortcut for the [`between`] combinator where the callee parser is the one in between.
 	fn between<PO, PC, OO, OC>(self, open: &PO, close: &PC) -> impl Parser<IT, O>
 	where

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -437,6 +437,15 @@ where
 		move |input| count_collect(&self, c)(input)
 	}
 
+	/// A shortcut for the [`once_or_more_until`] combinator.
+	fn once_or_more_until<PE, OE>(self, end: &PE) -> impl Parser<IT, usize>
+	where
+		Self: Sized,
+		PE: Parser<IT, OE>,
+	{
+		move |input| once_or_more_until(&self, end)(input)
+	}
+
 	/// A shortcut for the [`between`] combinator where the callee parser is the one in between.
 	fn between<PO, PC, OO, OC>(self, open: &PO, close: &PC) -> impl Parser<IT, O>
 	where

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -339,6 +339,24 @@ where
 		move |input| many_collect(&self)(input)
 	}
 
+	/// A shortcut for the [`many_until`] combinator.
+	fn many_until<PE, OE>(self, end: &PE) -> impl Parser<IT, usize>
+	where
+		Self: Sized,
+		PE: Parser<IT, OE>,
+	{
+		move |input| many_until(&self, end)(input)
+	}
+
+	/// A shortcut for the [`many_until_collect`] combinator.
+	fn many_until_collect<PE, OE>(self, end: &PE) -> impl Parser<IT, Vec<O>>
+	where
+		Self: Sized,
+		PE: Parser<IT, OE>,
+	{
+		move |input| many_until_collect(&self, end)(input)
+	}
+
 	/// A shortcut for the [`once_or_more`] combinator.
 	fn once_or_more(self) -> impl Parser<IT, usize>
 	where


### PR DESCRIPTION
# Overview
This version:
- Adds the `once_or_more_until` and `once_or_more_until_collect` combinators.
- Fix repetition parsers with `end` not failing whenever there is a minimum match count.
- Add shortcuts for `many_until` and `many_until_collect`.
- Add missing documentation sections to `many_until` and `many_until_collect`.

# New features
- New combinators `once_or_more_until` and `once_or_more_until_collect`: apply a parser one or more times, until another parser (called `end`) succeeds.

# Internal changes
- Rename some test cases to better reflect their nature.
- Make capitalization consistent in documentation.
