### PR TITLE
Release 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yapcol"
 description = "Yet Another Parser Combinator Library - YAPCoL"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "MIT"
 authors = ["Matheus Amazonas"]

--- a/src/combinators/repetition/at_least.rs
+++ b/src/combinators/repetition/at_least.rs
@@ -65,8 +65,9 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: CountAccumulator<O> = repeat_no_end(parser, min_count, None)(input)?;
-		Ok(accumulator.value())
+		let accumulator: CountAccumulator<O, _> = repeat_no_end(parser, min_count, None)(input)?;
+		let (count, _) = accumulator.result();
+		Ok(count)
 	}
 }
 

--- a/src/combinators/repetition/at_least_collect.rs
+++ b/src/combinators/repetition/at_least_collect.rs
@@ -70,8 +70,9 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: MatchesAccumulator<O> = repeat_no_end(parser, min_count, None)(input)?;
-		Ok(accumulator.value())
+		let accumulator: MatchesAccumulator<O, _> = repeat_no_end(parser, min_count, None)(input)?;
+		let (count, _) = accumulator.result();
+		Ok(count)
 	}
 }
 

--- a/src/combinators/repetition/core.rs
+++ b/src/combinators/repetition/core.rs
@@ -2,51 +2,71 @@ use crate::input::Position;
 use crate::{Error, Input, InputToken, Mismatch, Parser};
 use std::marker::PhantomData;
 
-pub trait RepetitionAccumulator<I, O> {
+pub trait RepetitionAccumulator<I, O, E> {
 	fn new() -> Self;
 	fn add(&mut self, value: I);
-	fn value(self) -> O;
+	fn end(&mut self, value: Option<E>);
+	fn result(self) -> (O, Option<E>);
 }
 
-pub struct MatchesAccumulator<T> {
+pub struct MatchesAccumulator<T, E> {
 	matches: Vec<T>,
+	end: Option<E>,
 }
 
-impl<T> RepetitionAccumulator<T, Vec<T>> for MatchesAccumulator<T> {
+impl<T, E> RepetitionAccumulator<T, Vec<T>, E> for MatchesAccumulator<T, E> {
 	fn new() -> Self {
 		MatchesAccumulator {
 			matches: Vec::new(),
+			end: None,
 		}
 	}
 
 	fn add(&mut self, value: T) {
+		if self.end.is_some() {
+			panic!("Cannot add more matches after the end of the repetition.");
+		}
 		self.matches.push(value);
 	}
 
-	fn value(self) -> Vec<T> {
-		self.matches
+	fn end(&mut self, value: Option<E>) {
+		self.end = value;
+	}
+
+	fn result(self) -> (Vec<T>, Option<E>) {
+		(self.matches, self.end)
 	}
 }
 
-pub struct CountAccumulator<T> {
+pub struct CountAccumulator<T, E> {
 	count: usize,
 	phantom: PhantomData<T>,
+	end: Option<E>,
 }
 
-impl<T> RepetitionAccumulator<T, usize> for CountAccumulator<T> {
+impl<T, E> RepetitionAccumulator<T, usize, E> for CountAccumulator<T, E> {
 	fn new() -> Self {
 		CountAccumulator {
 			count: 0,
 			phantom: PhantomData,
+			end: None,
 		}
 	}
 
 	fn add(&mut self, _: T) {
+		if self.end.is_some() {
+			panic!("Cannot add more matches after the end of the repetition.");
+		}
 		self.count += 1;
 	}
 
-	fn value(self) -> usize {
-		self.count
+	fn end(&mut self, end: Option<E>) {
+		// The end if not used, but it's useful to detect wrong calls to `add`.
+		self.end = end
+	}
+
+	fn result(self) -> (usize, Option<E>) {
+		(self.count, None)
 	}
 }
 
@@ -62,7 +82,7 @@ pub fn repeat_no_end<P, IT, O, A, AO>(
 where
 	P: Parser<IT, O>,
 	IT: InputToken,
-	A: RepetitionAccumulator<O, AO>,
+	A: RepetitionAccumulator<O, AO, ()>,
 {
 	move |input| repeat(parser, min_match_count, max_match_count, false, &fail)(input)
 }
@@ -77,29 +97,30 @@ where
 	P: Parser<IT, O>,
 	PE: Parser<IT, OE>,
 	IT: InputToken,
-	A: RepetitionAccumulator<O, AO>,
+	A: RepetitionAccumulator<O, AO, OE>,
 {
 	repeat(parser, min_match_count, max_match_count, true, end_parser)
 }
 
-fn repeat<P, PS, IT, O, OP, A, AO>(
+fn repeat<P, PE, IT, O, OE, A, AO>(
 	parser: &P,
 	min_match_count: usize,
 	max_match_count: Option<usize>,
 	fail_on_error: bool,
-	end_parser: &PS,
+	end_parser: &PE,
 ) -> impl Parser<IT, A>
 where
 	P: Parser<IT, O>,
-	PS: Parser<IT, OP>,
+	PE: Parser<IT, OE>,
 	IT: InputToken,
-	A: RepetitionAccumulator<O, AO>,
+	A: RepetitionAccumulator<O, AO, OE>,
 {
 	move |input| {
 		let mut accumulator = A::new();
 		let mut total_match_count = 0;
 		let mut previous_consumed_count = input.consumed_count();
-		while end_parser(input).is_err() {
+		let mut end_output = end_parser(input);
+		while end_output.is_err() {
 			let previous_position = input.position();
 			let outcome = parser(input);
 			match (outcome, max_match_count) {
@@ -133,8 +154,10 @@ where
 				(Err(_), _) if total_match_count >= min_match_count => return Ok(accumulator),
 				(Err(e), _) => return Err(e),
 			}
+			end_output = end_parser(input);
 		}
 		if total_match_count >= min_match_count {
+			accumulator.end(end_output.ok());
 			Ok(accumulator)
 		} else {
 			let expected = format!("at least {min_match_count} occurrences");
@@ -155,17 +178,17 @@ mod count_accumulator_tests {
 
 	#[test]
 	fn new_value_is_zero() {
-		let accumulator = CountAccumulator::<()>::new();
-		let count = accumulator.value();
-		assert_eq!(count, 0);
+		let accumulator = CountAccumulator::<(), ()>::new();
+		let result = accumulator.result();
+		assert_eq!(result, (0, None));
 	}
 
 	#[test]
 	fn add_once_is_one() {
-		let mut accumulator = CountAccumulator::<()>::new();
+		let mut accumulator = CountAccumulator::<(), ()>::new();
 		accumulator.add(());
-		let count = accumulator.value();
-		assert_eq!(count, 1);
+		let result = accumulator.result();
+		assert_eq!(result, (1, None));
 	}
 }
 
@@ -175,16 +198,25 @@ mod matches_accumulator_tests {
 
 	#[test]
 	fn new_value_is_zero() {
-		let accumulator = MatchesAccumulator::<()>::new();
-		let count = accumulator.value();
-		assert_eq!(count, vec![]);
+		let accumulator = MatchesAccumulator::<(), ()>::new();
+		let result = accumulator.result();
+		assert_eq!(result, (vec![], None));
 	}
 
 	#[test]
 	fn add_once_has_item() {
-		let mut accumulator = MatchesAccumulator::<usize>::new();
+		let mut accumulator = MatchesAccumulator::<usize, ()>::new();
 		accumulator.add(42);
-		let count = accumulator.value();
-		assert_eq!(count, vec![42]);
+		let result = accumulator.result();
+		assert_eq!(result, (vec![42], None));
+	}
+
+	#[test]
+	fn end_match() {
+		let mut accumulator = MatchesAccumulator::<usize, bool>::new();
+		accumulator.add(42);
+		accumulator.end(Some(true));
+		let result = accumulator.result();
+		assert_eq!(result, (vec![42], Some(true)));
 	}
 }

--- a/src/combinators/repetition/count.rs
+++ b/src/combinators/repetition/count.rs
@@ -60,8 +60,9 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: CountAccumulator<O> = repeat_no_end(parser, count, Some(count))(input)?;
-		Ok(accumulator.value())
+		let accumulator: CountAccumulator<O, _> = repeat_no_end(parser, count, Some(count))(input)?;
+		let (count, _) = accumulator.result();
+		Ok(count)
 	}
 }
 

--- a/src/combinators/repetition/count_collect.rs
+++ b/src/combinators/repetition/count_collect.rs
@@ -67,8 +67,10 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: MatchesAccumulator<O> = repeat_no_end(parser, count, Some(count))(input)?;
-		Ok(accumulator.value())
+		let accumulator: MatchesAccumulator<O, _> =
+			repeat_no_end(parser, count, Some(count))(input)?;
+		let (count, _) = accumulator.result();
+		Ok(count)
 	}
 }
 

--- a/src/combinators/repetition/many.rs
+++ b/src/combinators/repetition/many.rs
@@ -58,8 +58,9 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: CountAccumulator<O> = repeat_no_end(parser, 0, None)(input)?;
-		Ok(accumulator.value())
+		let accumulator: CountAccumulator<O, _> = repeat_no_end(parser, 0, None)(input)?;
+		let (count, _) = accumulator.result();
+		Ok(count)
 	}
 }
 

--- a/src/combinators/repetition/many_collect.rs
+++ b/src/combinators/repetition/many_collect.rs
@@ -65,8 +65,9 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: MatchesAccumulator<O> = repeat_no_end(parser, 0, None)(input)?;
-		Ok(accumulator.value())
+		let accumulator: MatchesAccumulator<O, _> = repeat_no_end(parser, 0, None)(input)?;
+		let (count, _) = accumulator.result();
+		Ok(count)
 	}
 }
 

--- a/src/combinators/repetition/many_until.rs
+++ b/src/combinators/repetition/many_until.rs
@@ -60,8 +60,9 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: CountAccumulator<O> = repeat_with_end(parser, 0, None, end)(input)?;
-		Ok(accumulator.value())
+		let accumulator: CountAccumulator<O, OE> = repeat_with_end(parser, 0, None, end)(input)?;
+		let (count, _) = accumulator.result();
+		Ok(count)
 	}
 }
 

--- a/src/combinators/repetition/many_until_collect.rs
+++ b/src/combinators/repetition/many_until_collect.rs
@@ -5,7 +5,9 @@ use crate::{InputToken, Parser};
 ///
 /// # Outcome
 ///
-/// If it succeeds, this combinator returns a vector of matches of its `parser` argument.
+/// If it succeeds, this combinator returns a tuple containing:
+///  - A vector of matches of its `parser` argument.
+///  - The match of its `end` argument parser.
 ///
 /// # Input consumption
 ///
@@ -54,18 +56,20 @@ use crate::{InputToken, Parser};
 /// 	many_until_collect(&any, &close)(input)
 /// };
 /// let mut input = Input::new_from_chars("#this is a comment$".chars(), None);
-/// let output = comments_parser(&mut input);
-/// assert_eq!(output, Ok("this is a comment".chars().collect()));
+/// let (matches, end) = comments_parser(&mut input).unwrap();
+/// assert_eq!(matches, "this is a comment".chars().collect::<Vec<char>>());
+/// assert_eq!(end, '$');
 /// ```
-pub fn many_until_collect<P, PE, IT, O, OE>(parser: &P, end: &PE) -> impl Parser<IT, Vec<O>>
+pub fn many_until_collect<P, PE, IT, O, OE>(parser: &P, end: &PE) -> impl Parser<IT, (Vec<O>, OE)>
 where
 	P: Parser<IT, O>,
 	PE: Parser<IT, OE>,
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: MatchesAccumulator<O> = repeat_with_end(parser, 0, None, end)(input)?;
-		Ok(accumulator.value())
+		let accumulator: MatchesAccumulator<O, OE> = repeat_with_end(parser, 0, None, end)(input)?;
+		let (count, end) = accumulator.result();
+		Ok((count, end.expect("End parser value is missing.")))
 	}
 }
 
@@ -79,8 +83,8 @@ mod tests {
 		let any_parser = any();
 		let end_comment_parser = is('#');
 		let mut input = Input::new_from_chars("".chars(), None);
-		let not_followed_parser = many_until_collect(&any_parser, &end_comment_parser);
-		let output = not_followed_parser(&mut input);
+		let many_until_collect_parser = many_until_collect(&any_parser, &end_comment_parser);
+		let output = many_until_collect_parser(&mut input);
 		assert_eq!(output, Err(Error::EndOfInput(None)));
 	}
 
@@ -89,9 +93,10 @@ mod tests {
 		let any_parser = any();
 		let end_comment_parser = is('#');
 		let mut input = Input::new_from_chars("#".chars(), None);
-		let not_followed_parser = many_until_collect(&any_parser, &end_comment_parser);
-		let output = not_followed_parser(&mut input).unwrap();
-		assert_eq!(output, Vec::<char>::new());
+		let many_until_collect_parser = many_until_collect(&any_parser, &end_comment_parser);
+		let (matches, end) = many_until_collect_parser(&mut input).unwrap();
+		assert_eq!(matches, Vec::<char>::new());
+		assert_eq!(end, '#');
 	}
 
 	#[test]
@@ -99,9 +104,10 @@ mod tests {
 		let any_parser = any();
 		let end_comment_parser = is('#');
 		let mut input = Input::new_from_chars("Hello world #".chars(), None);
-		let many_parser = many_until_collect(&any_parser, &end_comment_parser);
-		let output = many_parser(&mut input).unwrap();
-		assert_eq!(output, "Hello world ".chars().collect::<Vec<_>>());
+		let many_until_collect_parser = many_until_collect(&any_parser, &end_comment_parser);
+		let (matches, end) = many_until_collect_parser(&mut input).unwrap();
+		assert_eq!(matches, "Hello world ".chars().collect::<Vec<_>>());
+		assert_eq!(end, '#');
 	}
 
 	#[test]
@@ -109,8 +115,8 @@ mod tests {
 		let any_parser = is('x');
 		let end_comment_parser = is('#');
 		let mut input = Input::new_from_chars("xxxxxy".chars(), None);
-		let many_parser = many_until_collect(&any_parser, &end_comment_parser);
-		let output = many_parser(&mut input);
+		let many_until_collect_parser = many_until_collect(&any_parser, &end_comment_parser);
+		let output = many_until_collect_parser(&mut input);
 		let mismatch = Mismatch::new('x', 'y');
 		assert_eq!(
 			output,
@@ -128,8 +134,8 @@ mod tests {
 		let non_consuming = success(1); // Non-consuming parser.
 		let mut input = Input::new_from_chars("hello#".chars(), None);
 		let end_parser = is('#');
-		let parser = many_until_collect(&non_consuming, &end_parser);
-		let output = parser(&mut input);
+		let many_until_collect_parser = many_until_collect(&non_consuming, &end_parser);
+		let output = many_until_collect_parser(&mut input);
 		let position = Position::new(1, 1);
 		assert_eq!(output, Err(Error::NonConsumingLoop(None, position)));
 	}

--- a/src/combinators/repetition/once_or_more.rs
+++ b/src/combinators/repetition/once_or_more.rs
@@ -56,8 +56,9 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: CountAccumulator<O> = repeat_no_end(parser, 1, None)(input)?;
-		Ok(accumulator.value())
+		let accumulator: CountAccumulator<O, _> = repeat_no_end(parser, 1, None)(input)?;
+		let (count, _) = accumulator.result();
+		Ok(count)
 	}
 }
 

--- a/src/combinators/repetition/once_or_more_collect.rs
+++ b/src/combinators/repetition/once_or_more_collect.rs
@@ -63,8 +63,9 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: MatchesAccumulator<O> = repeat_no_end(parser, 1, None)(input)?;
-		Ok(accumulator.value())
+		let accumulator: MatchesAccumulator<O, _> = repeat_no_end(parser, 1, None)(input)?;
+		let (count, _) = accumulator.result();
+		Ok(count)
 	}
 }
 

--- a/src/combinators/repetition/once_or_more_until.rs
+++ b/src/combinators/repetition/once_or_more_until.rs
@@ -66,8 +66,9 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: CountAccumulator<O> = repeat_with_end(parser, 1, None, end)(input)?;
-		Ok(accumulator.value())
+		let accumulator: CountAccumulator<O, OE> = repeat_with_end(parser, 1, None, end)(input)?;
+		let (count, _) = accumulator.result();
+		Ok(count)
 	}
 }
 

--- a/src/combinators/repetition/once_or_more_until_collect.rs
+++ b/src/combinators/repetition/once_or_more_until_collect.rs
@@ -5,7 +5,9 @@ use crate::{InputToken, Parser};
 ///
 /// # Outcome
 ///
-/// If it succeeds, this combinator returns a vector of matches of its `parser` argument.
+/// If it succeeds, this combinator returns a tuple containing:
+///  - A vector of matches of its `parser` argument.
+///  - The match of its `end` argument parser.
 ///
 /// # Input consumption
 ///
@@ -55,23 +57,28 @@ use crate::{InputToken, Parser};
 /// };
 /// // Success if there is at least one character before the end.
 /// let mut input = Input::new_from_chars("#12345$".chars(), None);
-/// let output = comments_parser(&mut input);
-/// assert_eq!(output, Ok(vec!['1', '2', '3', '4', '5']));
+/// let (matches, end) = comments_parser(&mut input).unwrap();
+/// assert_eq!(matches, vec!['1', '2', '3', '4', '5']);
+/// assert_eq!(end, '$');
 ///
 /// // Fails if there is no character before the end.
 /// let mut input = Input::new_from_chars("#$".chars(), None);
 /// let output = comments_parser(&mut input);
 /// assert!(output.is_err());
 /// ```
-pub fn once_or_more_until_collect<P, PE, IT, O, OE>(parser: &P, end: &PE) -> impl Parser<IT, Vec<O>>
+pub fn once_or_more_until_collect<P, PE, IT, O, OE>(
+	parser: &P,
+	end: &PE,
+) -> impl Parser<IT, (Vec<O>, OE)>
 where
 	P: Parser<IT, O>,
 	PE: Parser<IT, OE>,
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: MatchesAccumulator<O> = repeat_with_end(parser, 1, None, end)(input)?;
-		Ok(accumulator.value())
+		let accumulator: MatchesAccumulator<O, OE> = repeat_with_end(parser, 1, None, end)(input)?;
+		let (count, end) = accumulator.result();
+		Ok((count, end.expect("End parser value is missing.")))
 	}
 }
 
@@ -114,8 +121,9 @@ mod tests {
 		let end_comment_parser = is('#');
 		let mut input = Input::new_from_chars("123456#".chars(), None);
 		let many_parser = once_or_more_until_collect(&any_parser, &end_comment_parser);
-		let output = many_parser(&mut input).unwrap();
-		assert_eq!(output, vec!['1', '2', '3', '4', '5', '6']);
+		let (matches, end) = many_parser(&mut input).unwrap();
+		assert_eq!(matches, vec!['1', '2', '3', '4', '5', '6']);
+		assert_eq!(end, '#');
 	}
 
 	#[test]

--- a/src/combinators/repetition/once_up_to.rs
+++ b/src/combinators/repetition/once_up_to.rs
@@ -74,8 +74,9 @@ where
 		panic!("max_count must be greater than 0");
 	}
 	move |input| {
-		let accumulator: CountAccumulator<O> = repeat_no_end(parser, 1, Some(max_count))(input)?;
-		Ok(accumulator.value())
+		let accumulator: CountAccumulator<O, _> = repeat_no_end(parser, 1, Some(max_count))(input)?;
+		let (count, _) = accumulator.result();
+		Ok(count)
 	}
 }
 

--- a/src/combinators/repetition/once_up_to_collect.rs
+++ b/src/combinators/repetition/once_up_to_collect.rs
@@ -87,8 +87,10 @@ where
 		panic!("max_count must be greater than 0");
 	}
 	move |input| {
-		let accumulator: MatchesAccumulator<O> = repeat_no_end(parser, 1, Some(max_count))(input)?;
-		Ok(accumulator.value())
+		let accumulator: MatchesAccumulator<O, _> =
+			repeat_no_end(parser, 1, Some(max_count))(input)?;
+		let (count, _) = accumulator.result();
+		Ok(count)
 	}
 }
 

--- a/src/combinators/repetition/up_to.rs
+++ b/src/combinators/repetition/up_to.rs
@@ -70,8 +70,9 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: CountAccumulator<O> = repeat_no_end(parser, 0, Some(max_count))(input)?;
-		Ok(accumulator.value())
+		let accumulator: CountAccumulator<O, _> = repeat_no_end(parser, 0, Some(max_count))(input)?;
+		let (count, _) = accumulator.result();
+		Ok(count)
 	}
 }
 

--- a/src/combinators/repetition/up_to_collect.rs
+++ b/src/combinators/repetition/up_to_collect.rs
@@ -84,8 +84,10 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: MatchesAccumulator<O> = repeat_no_end(parser, 0, Some(max_count))(input)?;
-		Ok(accumulator.value())
+		let accumulator: MatchesAccumulator<O, _> =
+			repeat_no_end(parser, 0, Some(max_count))(input)?;
+		let (count, _) = accumulator.result();
+		Ok(count)
 	}
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -349,7 +349,7 @@ where
 	}
 
 	/// A shortcut for the [`many_until_collect`] combinator.
-	fn many_until_collect<PE, OE>(self, end: &PE) -> impl Parser<IT, Vec<O>>
+	fn many_until_collect<PE, OE>(self, end: &PE) -> impl Parser<IT, (Vec<O>, OE)>
 	where
 		Self: Sized,
 		PE: Parser<IT, OE>,
@@ -447,7 +447,7 @@ where
 	}
 
 	/// A shortcut for the [`once_or_more_until_collect`] combinator.
-	fn once_or_more_until_collect<PE, OE>(self, end: &PE) -> impl Parser<IT, Vec<O>>
+	fn once_or_more_until_collect<PE, OE>(self, end: &PE) -> impl Parser<IT, (Vec<O>, OE)>
 	where
 		Self: Sized,
 		PE: Parser<IT, OE>,


### PR DESCRIPTION
# Overview
This version:
- Adds `end` parser match to the return of some repetition combinators.

# Breaking changes
- Change the return type of the following combinators from `impl Parser<IT, Vec<O>>`to `impl Parser<IT, (Vec<O>, OE)>`:
  - `many_until_collect`.
  - `once_or_more_until_collect`.

# New features
- The following parsers now also return the match of its `end` parser:
  - `many_until_collect`.
  - `once_or_more_until_collect`.

# Internal changes
- Fix some wrong names in `many_until_collect` test code.