### PR TITLE
Release 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yapcol"
 description = "Yet Another Parser Combinator Library - YAPCoL"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 license = "MIT"
 authors = ["Matheus Amazonas"]

--- a/src/combinators/look_ahead.rs
+++ b/src/combinators/look_ahead.rs
@@ -148,6 +148,29 @@ mod tests {
 	}
 
 	#[test]
+	fn attempt_with_look_ahead_does_not_consume() {
+		let parser = is('h').and(is('e')).look_ahead();
+		let mut input = Input::new_from_chars("hallo".chars(), None);
+		let output = attempt(&parser)(&mut input);
+		let mismatch = Mismatch::new('e', 'a');
+		assert_eq!(
+			output,
+			Err(Error::UnexpectedToken(
+				None,
+				Position::new(1, 2),
+				Some(mismatch)
+			))
+		);
+		// Input should still be intact.
+		assert_eq!(any()(&mut input), Ok('h'));
+		assert_eq!(any()(&mut input), Ok('a'));
+		assert_eq!(any()(&mut input), Ok('l'));
+		assert_eq!(any()(&mut input), Ok('l'));
+		assert_eq!(any()(&mut input), Ok('o'));
+		assert!(end_of_input()(&mut input).is_ok());
+	}
+
+	#[test]
 	fn parse_does_not_consume_on_failure() {
 		let parser = is('h');
 		let mut input = Input::new_from_chars("jello".chars(), None);

--- a/src/combinators/repetition/at_least.rs
+++ b/src/combinators/repetition/at_least.rs
@@ -1,4 +1,4 @@
-use super::core::{CountAccumulator, RepetitionAccumulator, repeat_no_end};
+use super::core::repeat_no_end;
 use crate::{InputToken, Parser};
 
 /// Applies `parser` at least a given number of times (and possibly more).
@@ -65,8 +65,7 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: CountAccumulator<O, _> = repeat_no_end(parser, min_count, None)(input)?;
-		let (count, _) = accumulator.result();
+		let count = repeat_no_end(parser, min_count, None)(input)?;
 		Ok(count)
 	}
 }

--- a/src/combinators/repetition/at_least_collect.rs
+++ b/src/combinators/repetition/at_least_collect.rs
@@ -1,4 +1,4 @@
-use super::core::{MatchesAccumulator, RepetitionAccumulator, repeat_no_end};
+use super::core::repeat_no_end_collect;
 use crate::{InputToken, Parser};
 
 /// Applies `parser` at least a given number of times (and possibly more), collecting the matches.
@@ -70,8 +70,7 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: MatchesAccumulator<O, _> = repeat_no_end(parser, min_count, None)(input)?;
-		let (count, _) = accumulator.result();
+		let (count, _) = repeat_no_end_collect(parser, min_count, None)(input)?;
 		Ok(count)
 	}
 }

--- a/src/combinators/repetition/core.rs
+++ b/src/combinators/repetition/core.rs
@@ -2,71 +2,51 @@ use crate::input::Position;
 use crate::{Error, Input, InputToken, Mismatch, Parser};
 use std::marker::PhantomData;
 
-pub trait RepetitionAccumulator<I, O, E> {
+trait RepetitionAccumulator<I, O> {
 	fn new() -> Self;
 	fn add(&mut self, value: I);
-	fn end(&mut self, value: Option<E>);
-	fn result(self) -> (O, Option<E>);
+	fn end(self) -> O;
 }
 
-pub struct MatchesAccumulator<T, E> {
+struct MatchesAccumulator<T> {
 	matches: Vec<T>,
-	end: Option<E>,
 }
 
-impl<T, E> RepetitionAccumulator<T, Vec<T>, E> for MatchesAccumulator<T, E> {
+impl<T> RepetitionAccumulator<T, Vec<T>> for MatchesAccumulator<T> {
 	fn new() -> Self {
 		MatchesAccumulator {
 			matches: Vec::new(),
-			end: None,
 		}
 	}
 
 	fn add(&mut self, value: T) {
-		if self.end.is_some() {
-			panic!("Cannot add more matches after the end of the repetition.");
-		}
 		self.matches.push(value);
 	}
 
-	fn end(&mut self, value: Option<E>) {
-		self.end = value;
-	}
-
-	fn result(self) -> (Vec<T>, Option<E>) {
-		(self.matches, self.end)
+	fn end(self) -> Vec<T> {
+		self.matches
 	}
 }
 
-pub struct CountAccumulator<T, E> {
+struct CountAccumulator<T> {
 	count: usize,
 	phantom: PhantomData<T>,
-	end: Option<E>,
 }
 
-impl<T, E> RepetitionAccumulator<T, usize, E> for CountAccumulator<T, E> {
+impl<T> RepetitionAccumulator<T, usize> for CountAccumulator<T> {
 	fn new() -> Self {
 		CountAccumulator {
 			count: 0,
 			phantom: PhantomData,
-			end: None,
 		}
 	}
 
 	fn add(&mut self, _: T) {
-		if self.end.is_some() {
-			panic!("Cannot add more matches after the end of the repetition.");
-		}
 		self.count += 1;
 	}
 
-	fn end(&mut self, end: Option<E>) {
-		// The end if not used, but it's useful to detect wrong calls to `add`.
-		self.end = end
-	}
-
-	fn result(self) -> (usize, Option<E>) {
-		(self.count, None)
+	fn end(self) -> usize {
+		self.count
 	}
 }
 
@@ -74,32 +54,86 @@ fn fail<IT>(_: &mut Input<IT>) -> Result<(), Error> {
 	Err(Error::UnexpectedToken(None, Position::new(0, 0), None))
 }
 
-pub fn repeat_no_end<P, IT, O, A, AO>(
+pub fn repeat_no_end<P, IT, O>(
 	parser: &P,
 	min_match_count: usize,
 	max_match_count: Option<usize>,
-) -> impl Parser<IT, A>
+) -> impl Parser<IT, usize>
 where
 	P: Parser<IT, O>,
 	IT: InputToken,
-	A: RepetitionAccumulator<O, AO, ()>,
 {
-	move |input| repeat(parser, min_match_count, max_match_count, false, &fail)(input)
+	move |input| {
+		repeat::<P, _, IT, O, (), CountAccumulator<O>, usize>(
+			parser,
+			min_match_count,
+			max_match_count,
+			false,
+			&fail,
+		)(input)
+		.map(|(count, _)| count)
+	}
 }
 
-pub fn repeat_with_end<P, PE, IT, O, OE, A, AO>(
+pub fn repeat_no_end_collect<P, IT, O>(
+	parser: &P,
+	min_match_count: usize,
+	max_match_count: Option<usize>,
+) -> impl Parser<IT, (Vec<O>, Option<()>)>
+where
+	P: Parser<IT, O>,
+	IT: InputToken,
+{
+	move |input| {
+		repeat::<P, _, IT, O, (), MatchesAccumulator<O>, Vec<O>>(
+			parser,
+			min_match_count,
+			max_match_count,
+			false,
+			&fail,
+		)(input)
+	}
+}
+
+pub fn repeat_with_end<P, PE, IT, O, OE>(
 	parser: &P,
 	min_match_count: usize,
 	max_match_count: Option<usize>,
 	end_parser: &PE,
-) -> impl Parser<IT, A>
+) -> impl Parser<IT, usize>
 where
 	P: Parser<IT, O>,
 	PE: Parser<IT, OE>,
 	IT: InputToken,
-	A: RepetitionAccumulator<O, AO, OE>,
 {
-	repeat(parser, min_match_count, max_match_count, true, end_parser)
+	repeat::<P, PE, IT, O, OE, CountAccumulator<O>, usize>(
+		parser,
+		min_match_count,
+		max_match_count,
+		true,
+		end_parser,
+	)
+	.map(|(count, _)| count)
+}
+
+pub fn repeat_with_end_collect<P, PE, IT, O, OE>(
+	parser: &P,
+	min_match_count: usize,
+	max_match_count: Option<usize>,
+	end_parser: &PE,
+) -> impl Parser<IT, (Vec<O>, Option<OE>)>
+where
+	P: Parser<IT, O>,
+	PE: Parser<IT, OE>,
+	IT: InputToken,
+{
+	repeat::<P, PE, IT, O, OE, MatchesAccumulator<O>, Vec<O>>(
+		parser,
+		min_match_count,
+		max_match_count,
+		true,
+		end_parser,
+	)
 }
 
 fn repeat<P, PE, IT, O, OE, A, AO>(
@@ -108,12 +142,12 @@ fn repeat<P, PE, IT, O, OE, A, AO>(
 	max_match_count: Option<usize>,
 	fail_on_error: bool,
 	end_parser: &PE,
-) -> impl Parser<IT, A>
+) -> impl Parser<IT, (AO, Option<OE>)>
 where
 	P: Parser<IT, O>,
 	PE: Parser<IT, OE>,
 	IT: InputToken,
-	A: RepetitionAccumulator<O, AO, OE>,
+	A: RepetitionAccumulator<O, AO>,
 {
 	move |input| {
 		let mut accumulator = A::new();
@@ -151,14 +185,19 @@ where
 					previous_consumed_count = consumed_count;
 				}
 				(Err(e), _) if fail_on_error => return Err(e),
-				(Err(_), _) if total_match_count >= min_match_count => return Ok(accumulator),
+				(Err(_), _) if total_match_count >= min_match_count => {
+					let result = accumulator.end();
+					return Ok((result, None));
+				}
 				(Err(e), _) => return Err(e),
 			}
 			end_output = end_parser(input);
 		}
+		// End parser matched. Wrap-up.
 		if total_match_count >= min_match_count {
-			accumulator.end(end_output.ok());
-			Ok(accumulator)
+			let result = accumulator.end();
+			let end = end_output.ok();
+			Ok((result, end))
 		} else {
 			let expected = format!("at least {min_match_count} occurrences");
 			let found = format!("{total_match_count} occurrences");
@@ -178,17 +217,17 @@ mod count_accumulator_tests {
 
 	#[test]
 	fn new_value_is_zero() {
-		let accumulator = CountAccumulator::<(), ()>::new();
-		let result = accumulator.result();
-		assert_eq!(result, (0, None));
+		let accumulator = CountAccumulator::<()>::new();
+		let result = accumulator.end();
+		assert_eq!(result, 0);
 	}
 
 	#[test]
 	fn add_once_is_one() {
-		let mut accumulator = CountAccumulator::<(), ()>::new();
+		let mut accumulator = CountAccumulator::<()>::new();
 		accumulator.add(());
-		let result = accumulator.result();
-		assert_eq!(result, (1, None));
+		let result = accumulator.end();
+		assert_eq!(result, 1);
 	}
 }
 
@@ -198,25 +237,16 @@ mod matches_accumulator_tests {
 
 	#[test]
 	fn new_value_is_zero() {
-		let accumulator = MatchesAccumulator::<(), ()>::new();
-		let result = accumulator.result();
-		assert_eq!(result, (vec![], None));
+		let accumulator = MatchesAccumulator::<()>::new();
+		let result = accumulator.end();
+		assert_eq!(result, vec![]);
 	}
 
 	#[test]
 	fn add_once_has_item() {
-		let mut accumulator = MatchesAccumulator::<usize, ()>::new();
+		let mut accumulator = MatchesAccumulator::<usize>::new();
 		accumulator.add(42);
-		let result = accumulator.result();
-		assert_eq!(result, (vec![42], None));
-	}
-
-	#[test]
-	fn end_match() {
-		let mut accumulator = MatchesAccumulator::<usize, bool>::new();
-		accumulator.add(42);
-		accumulator.end(Some(true));
-		let result = accumulator.result();
-		assert_eq!(result, (vec![42], Some(true)));
+		let result = accumulator.end();
+		assert_eq!(result, vec![42]);
 	}
 }

--- a/src/combinators/repetition/count.rs
+++ b/src/combinators/repetition/count.rs
@@ -1,4 +1,4 @@
-use super::core::{CountAccumulator, RepetitionAccumulator, repeat_no_end};
+use super::core::repeat_no_end;
 use crate::{InputToken, Parser};
 
 /// Creates a parser that applies the given parser exactly `count` times.
@@ -60,8 +60,7 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: CountAccumulator<O, _> = repeat_no_end(parser, count, Some(count))(input)?;
-		let (count, _) = accumulator.result();
+		let count = repeat_no_end(parser, count, Some(count))(input)?;
 		Ok(count)
 	}
 }

--- a/src/combinators/repetition/count_collect.rs
+++ b/src/combinators/repetition/count_collect.rs
@@ -1,4 +1,4 @@
-use super::core::{MatchesAccumulator, RepetitionAccumulator, repeat_no_end};
+use super::core::repeat_no_end_collect;
 use crate::{InputToken, Parser};
 
 /// Creates a parser that applies the given parser exactly `count` times, collecting the matches.
@@ -67,9 +67,7 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: MatchesAccumulator<O, _> =
-			repeat_no_end(parser, count, Some(count))(input)?;
-		let (count, _) = accumulator.result();
+		let (count, _) = repeat_no_end_collect(parser, count, Some(count))(input)?;
 		Ok(count)
 	}
 }

--- a/src/combinators/repetition/many.rs
+++ b/src/combinators/repetition/many.rs
@@ -1,4 +1,4 @@
-use super::core::{CountAccumulator, RepetitionAccumulator, repeat_no_end};
+use super::core::repeat_no_end;
 use crate::{InputToken, Parser};
 
 /// Applies `parser` zero or more time.
@@ -58,8 +58,7 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: CountAccumulator<O, _> = repeat_no_end(parser, 0, None)(input)?;
-		let (count, _) = accumulator.result();
+		let count = repeat_no_end(parser, 0, None)(input)?;
 		Ok(count)
 	}
 }

--- a/src/combinators/repetition/many_collect.rs
+++ b/src/combinators/repetition/many_collect.rs
@@ -1,4 +1,4 @@
-use super::core::{MatchesAccumulator, RepetitionAccumulator, repeat_no_end};
+use super::core::repeat_no_end_collect;
 use crate::{InputToken, Parser};
 
 /// Applies `parser` zero or more times, collecting all the potential matches.
@@ -65,8 +65,7 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: MatchesAccumulator<O, _> = repeat_no_end(parser, 0, None)(input)?;
-		let (count, _) = accumulator.result();
+		let (count, _) = repeat_no_end_collect(parser, 0, None)(input)?;
 		Ok(count)
 	}
 }

--- a/src/combinators/repetition/many_until.rs
+++ b/src/combinators/repetition/many_until.rs
@@ -1,4 +1,4 @@
-use super::core::{CountAccumulator, RepetitionAccumulator, repeat_with_end};
+use super::core::repeat_with_end;
 use crate::{InputToken, Parser};
 
 /// Parses zero or more instances of `parser`, until `end` succeeds.
@@ -60,8 +60,7 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: CountAccumulator<O, OE> = repeat_with_end(parser, 0, None, end)(input)?;
-		let (count, _) = accumulator.result();
+		let count = repeat_with_end(parser, 0, None, end)(input)?;
 		Ok(count)
 	}
 }

--- a/src/combinators/repetition/many_until_collect.rs
+++ b/src/combinators/repetition/many_until_collect.rs
@@ -1,4 +1,4 @@
-use super::core::{MatchesAccumulator, RepetitionAccumulator, repeat_with_end};
+use super::core::repeat_with_end_collect;
 use crate::{InputToken, Parser};
 
 /// Parses zero or more instances of `parser`, until `end` succeeds, collecting all the matches.
@@ -67,8 +67,7 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: MatchesAccumulator<O, OE> = repeat_with_end(parser, 0, None, end)(input)?;
-		let (count, end) = accumulator.result();
+		let (count, end) = repeat_with_end_collect(parser, 0, None, end)(input)?;
 		Ok((count, end.expect("End parser value is missing.")))
 	}
 }

--- a/src/combinators/repetition/once_or_more.rs
+++ b/src/combinators/repetition/once_or_more.rs
@@ -1,4 +1,4 @@
-use super::core::{CountAccumulator, RepetitionAccumulator, repeat_no_end};
+use super::core::repeat_no_end;
 use crate::{InputToken, Parser};
 
 /// Applies `parser` one or more times.
@@ -56,8 +56,7 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: CountAccumulator<O, _> = repeat_no_end(parser, 1, None)(input)?;
-		let (count, _) = accumulator.result();
+		let count = repeat_no_end(parser, 1, None)(input)?;
 		Ok(count)
 	}
 }

--- a/src/combinators/repetition/once_or_more_collect.rs
+++ b/src/combinators/repetition/once_or_more_collect.rs
@@ -1,4 +1,4 @@
-use super::core::{MatchesAccumulator, RepetitionAccumulator, repeat_no_end};
+use super::core::repeat_no_end_collect;
 use crate::{InputToken, Parser};
 
 /// Applies `parser` one or more times, collecting all the matches.
@@ -63,9 +63,8 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: MatchesAccumulator<O, _> = repeat_no_end(parser, 1, None)(input)?;
-		let (count, _) = accumulator.result();
-		Ok(count)
+		let (matches, _) = repeat_no_end_collect(parser, 1, None)(input)?;
+		Ok(matches)
 	}
 }
 

--- a/src/combinators/repetition/once_or_more_until.rs
+++ b/src/combinators/repetition/once_or_more_until.rs
@@ -1,4 +1,4 @@
-use super::core::{CountAccumulator, RepetitionAccumulator, repeat_with_end};
+use super::core::repeat_with_end;
 use crate::{InputToken, Parser};
 
 /// Applies `parser` one or more times, until `end` succeeds.
@@ -66,8 +66,7 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: CountAccumulator<O, OE> = repeat_with_end(parser, 1, None, end)(input)?;
-		let (count, _) = accumulator.result();
+		let count = repeat_with_end(parser, 1, None, end)(input)?;
 		Ok(count)
 	}
 }

--- a/src/combinators/repetition/once_or_more_until_collect.rs
+++ b/src/combinators/repetition/once_or_more_until_collect.rs
@@ -1,4 +1,4 @@
-use super::core::{MatchesAccumulator, RepetitionAccumulator, repeat_with_end};
+use super::core::repeat_with_end_collect;
 use crate::{InputToken, Parser};
 
 /// Applies `parser` one or more times, until `end` succeeds, collecting all the matches.
@@ -76,8 +76,7 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: MatchesAccumulator<O, OE> = repeat_with_end(parser, 1, None, end)(input)?;
-		let (count, end) = accumulator.result();
+		let (count, end) = repeat_with_end_collect(parser, 1, None, end)(input)?;
 		Ok((count, end.expect("End parser value is missing.")))
 	}
 }

--- a/src/combinators/repetition/once_up_to.rs
+++ b/src/combinators/repetition/once_up_to.rs
@@ -1,4 +1,4 @@
-use super::core::{CountAccumulator, RepetitionAccumulator, repeat_no_end};
+use super::core::repeat_no_end;
 use crate::{InputToken, Parser};
 
 /// Applies `parser` between 1 and a given number of times, ensuring that no more matches occur.
@@ -74,8 +74,7 @@ where
 		panic!("max_count must be greater than 0");
 	}
 	move |input| {
-		let accumulator: CountAccumulator<O, _> = repeat_no_end(parser, 1, Some(max_count))(input)?;
-		let (count, _) = accumulator.result();
+		let count = repeat_no_end(parser, 1, Some(max_count))(input)?;
 		Ok(count)
 	}
 }

--- a/src/combinators/repetition/once_up_to_collect.rs
+++ b/src/combinators/repetition/once_up_to_collect.rs
@@ -1,4 +1,4 @@
-use super::core::{MatchesAccumulator, RepetitionAccumulator, repeat_no_end};
+use super::core::repeat_no_end_collect;
 use crate::{InputToken, Parser};
 
 /// Applies `parser` between 1 and a given number of times, ensuring that no more matches occur and
@@ -87,9 +87,7 @@ where
 		panic!("max_count must be greater than 0");
 	}
 	move |input| {
-		let accumulator: MatchesAccumulator<O, _> =
-			repeat_no_end(parser, 1, Some(max_count))(input)?;
-		let (count, _) = accumulator.result();
+		let (count, _) = repeat_no_end_collect(parser, 1, Some(max_count))(input)?;
 		Ok(count)
 	}
 }

--- a/src/combinators/repetition/up_to.rs
+++ b/src/combinators/repetition/up_to.rs
@@ -1,4 +1,4 @@
-use super::core::{CountAccumulator, RepetitionAccumulator, repeat_no_end};
+use super::core::repeat_no_end;
 use crate::{InputToken, Parser};
 
 /// Applies `parser` between 0 and a given number of times, ensuring that no more matches occur.
@@ -70,8 +70,7 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: CountAccumulator<O, _> = repeat_no_end(parser, 0, Some(max_count))(input)?;
-		let (count, _) = accumulator.result();
+		let count = repeat_no_end(parser, 0, Some(max_count))(input)?;
 		Ok(count)
 	}
 }

--- a/src/combinators/repetition/up_to_collect.rs
+++ b/src/combinators/repetition/up_to_collect.rs
@@ -1,4 +1,4 @@
-use super::core::{MatchesAccumulator, RepetitionAccumulator, repeat_no_end};
+use super::core::repeat_no_end_collect;
 use crate::{InputToken, Parser};
 
 /// Applies `parser` between 0 and a given number of times, ensuring that no more matches occur and
@@ -84,9 +84,7 @@ where
 	IT: InputToken,
 {
 	move |input| {
-		let accumulator: MatchesAccumulator<O, _> =
-			repeat_no_end(parser, 0, Some(max_count))(input)?;
-		let (count, _) = accumulator.result();
+		let (count, _) = repeat_no_end_collect(parser, 0, Some(max_count))(input)?;
 		Ok(count)
 	}
 }

--- a/src/input/core.rs
+++ b/src/input/core.rs
@@ -111,7 +111,7 @@ where
 						self.last_token_position = token.position();
 						let cloned = token.clone();
 						self.look_ahead_buffer.push_back(token);
-						frame.increment();
+						frame.add_count(1);
 						self.consumed_count += 1;
 						Some(cloned)
 					}
@@ -132,7 +132,7 @@ where
 			TokenLocation::BufferTail => {
 				let frame = self.look_ahead_frames.last_mut().unwrap();
 				let token = self.look_ahead_buffer.get(frame.next_token_ix()).unwrap();
-				frame.increment();
+				frame.add_count(1);
 				self.next_location = if frame.next_token_ix() == self.look_ahead_buffer.len() {
 					TokenLocation::StreamLookingAhead
 				} else {
@@ -147,7 +147,7 @@ where
 
 	/// Peeks into the input, returning a reference to the next token. Calling this method does not
 	/// mutate the input, and calling it repeatedly will return the same item over and over.
-	pub(crate) fn peek(&mut self) -> Option<&IT> {
+	pub fn peek(&mut self) -> Option<&IT> {
 		match self.next_location {
 			TokenLocation::Stream => self.source.peek(),
 			TokenLocation::StreamLookingAhead => self.source.peek(),
@@ -244,9 +244,13 @@ where
 		if backtrack {
 			self.consumed_count -= frame.length();
 		} else {
-			let buffer_length = self.look_ahead_buffer.len();
-			self.look_ahead_buffer
-				.truncate(buffer_length - frame.length());
+			if let Some(previous_frame) = self.look_ahead_frames.last_mut() {
+				previous_frame.add_count(frame.length())
+			} else {
+				let buffer_length = self.look_ahead_buffer.len();
+				self.look_ahead_buffer
+					.truncate(buffer_length - frame.length());
+			}
 		}
 
 		self.next_location = if self.look_ahead_frames.is_empty() {
@@ -278,10 +282,15 @@ mod tests {
 	#[test]
 	fn lookahead_no_backtracking() {
 		let mut input = Input::new_from_chars("12".chars(), None);
+		assert_eq!(input.next_location, TokenLocation::Stream);
 		let handler = input.start_look_ahead();
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		assert_eq!(input.next_token().unwrap().token_owned(), '1');
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		assert_eq!(input.next_token().unwrap().token_owned(), '2');
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		input.stop_look_ahead(handler, false);
+		assert_eq!(input.next_location, TokenLocation::Stream);
 		assert!(input.look_ahead_buffer.is_empty());
 		assert_eq!(input.consumed_count(), 2);
 		assert_eq!(input.look_ahead_frames.len(), 0);
@@ -291,10 +300,13 @@ mod tests {
 	#[test]
 	fn lookahead_backtracking() {
 		let mut input = Input::new_from_chars("12".chars(), None);
+		assert_eq!(input.next_location, TokenLocation::Stream);
 		let handler = input.start_look_ahead();
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		assert_eq!(input.next_token().unwrap().token_owned(), '1');
 		assert_eq!(input.next_token().unwrap().token_owned(), '2');
 		input.stop_look_ahead(handler, true);
+		assert_eq!(input.next_location, TokenLocation::BufferHead);
 		assert!(!input.look_ahead_buffer.is_empty());
 		assert_eq!(input.consumed_count(), 0);
 		assert_eq!(input.next_token().unwrap().token_owned(), '1');
@@ -359,53 +371,92 @@ mod tests {
 	#[test]
 	fn nested_lookahead_backtrack() {
 		let mut input = Input::new_from_chars("12345".chars(), None);
+		assert_eq!(input.next_location, TokenLocation::Stream);
 		let handler1 = input.start_look_ahead();
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		assert_eq!(input.next_token().unwrap().token_owned(), '1');
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		let handler2 = input.start_look_ahead();
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		assert_eq!(input.next_token().unwrap().token_owned(), '2');
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		input.stop_look_ahead(handler2, true);
+		assert_eq!(input.next_location, TokenLocation::BufferTail);
 		assert_eq!(input.next_token().unwrap().token_owned(), '2');
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		input.stop_look_ahead(handler1, true);
+		assert_eq!(input.next_location, TokenLocation::BufferHead);
 		assert_eq!(input.next_token().unwrap().token_owned(), '1');
+		assert_eq!(input.next_location, TokenLocation::BufferHead);
+		assert_eq!(input.next_token().unwrap().token_owned(), '2');
+		assert_eq!(input.next_location, TokenLocation::Stream);
 	}
 
 	#[test]
 	fn nested_lookahead_no_backtrack() {
 		let mut input = Input::new_from_chars("12345".chars(), None);
+		assert_eq!(input.next_location, TokenLocation::Stream);
 		let handler1 = input.start_look_ahead();
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		assert_eq!(input.next_token().unwrap().token_owned(), '1');
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		let handler2 = input.start_look_ahead();
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		assert_eq!(input.next_token().unwrap().token_owned(), '2');
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		input.stop_look_ahead(handler2, false);
 		assert_eq!(input.next_token().unwrap().token_owned(), '3');
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		input.stop_look_ahead(handler1, false);
+		assert_eq!(input.next_location, TokenLocation::Stream);
 		assert_eq!(input.next_token().unwrap().token_owned(), '4');
 	}
 
 	#[test]
 	fn nested_look_ahead_backtrack_first() {
 		let mut input = Input::new_from_chars("12345".chars(), None);
+		assert_eq!(input.next_location, TokenLocation::Stream);
 		let handler1 = input.start_look_ahead();
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		assert_eq!(input.next_token().unwrap().token_owned(), '1');
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		let handler2 = input.start_look_ahead();
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		assert_eq!(input.next_token().unwrap().token_owned(), '2');
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		input.stop_look_ahead(handler2, true);
+		assert_eq!(input.next_location, TokenLocation::BufferTail);
 		assert_eq!(input.next_token().unwrap().token_owned(), '2');
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		input.stop_look_ahead(handler1, false);
+		assert_eq!(input.next_location, TokenLocation::Stream);
 		assert_eq!(input.next_token().unwrap().token_owned(), '3');
 	}
 
 	#[test]
 	fn nested_look_ahead_backtrack_second() {
 		let mut input = Input::new_from_chars("12345".chars(), None);
+		assert_eq!(input.next_location, TokenLocation::Stream);
 		let handler1 = input.start_look_ahead();
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		assert_eq!(input.next_token().unwrap().token_owned(), '1');
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		let handler2 = input.start_look_ahead();
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		assert_eq!(input.next_token().unwrap().token_owned(), '2');
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		input.stop_look_ahead(handler2, false);
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		assert_eq!(input.next_token().unwrap().token_owned(), '3');
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		input.stop_look_ahead(handler1, true);
+		assert_eq!(input.next_location, TokenLocation::BufferHead);
 		assert_eq!(input.next_token().unwrap().token_owned(), '1');
+		assert_eq!(input.next_location, TokenLocation::BufferHead);
+		assert_eq!(input.next_token().unwrap().token_owned(), '2');
+		assert_eq!(input.next_location, TokenLocation::BufferHead);
+		assert_eq!(input.next_token().unwrap().token_owned(), '3');
+		assert_eq!(input.next_location, TokenLocation::Stream);
 	}
 
 	#[test]

--- a/src/input/lookahead.rs
+++ b/src/input/lookahead.rs
@@ -26,8 +26,8 @@ impl LookAheadFrame {
 	}
 
 	/// Increments the number of tokens placed in this frame.
-	pub fn increment(&mut self) {
-		self.length += 1;
+	pub fn add_count(&mut self, count: usize) {
+		self.length += count;
 	}
 }
 
@@ -53,6 +53,7 @@ impl LookAheadHandler {
 }
 
 /// Possible locations where the next input token might be.
+#[derive(Debug, PartialEq)]
 pub enum TokenLocation {
 	/// The next token will be fetched directly from the underlying source stream.
 	Stream,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -315,6 +315,14 @@ where
 		move |input| attempt(&self)(input)
 	}
 
+	/// A shortcut for the [`look_ahead`] combinator.
+	fn look_ahead(self) -> impl Parser<IT, O>
+	where
+		Self: Sized,
+	{
+		move |input| look_ahead(&self)(input)
+	}
+
 	/// A shortcut for the [`maybe`] combinator.
 	fn maybe(self) -> impl Parser<IT, Option<O>>
 	where


### PR DESCRIPTION
# Overview
This version:
- Fixes `attempt` + `look_ahead` not backtracking completely
- Adds `Parser::look_ahead` method.

# New features
- `Parser::look_ahead` method, a shortcut for the `attempt` combinator.

# Internal changes
- Simplify `repetition::core` so it doesn't panic and its accumulators are internal.