### PR TITLE
Release 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yapcol"
 description = "Yet Another Parser Combinator Library - YAPCoL"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "MIT"
 authors = ["Matheus Amazonas"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ powerful features like arbitrary lookahead and nested parsers.
 Add YAPCoL to your `Cargo.toml`:
 ```toml
 [dependencies]
-yapcol = "0.5.0"
+yapcol = "0.8.0"
 ```
 
 Or use `cargo add`:
@@ -31,7 +31,7 @@ cargo add yapcol
 
 - Basic: `is`, `satisfy`, `any`, `end_of_input`, `success`.
 - Choice and Optional: `choice`, `maybe`, `either`.
-- Repetition: `at_least`, `count`, `many`, `many_until`, `once_or_more`, `once_up_to`, `up_to`, and variations that collect the matches.
+- Repetition: `at_least`, `count`, `many`, `many_until`, `once_or_more`, `once_or_more_until`, `once_up_to`, `up_to`, and variations that collect the matches.
 - Lookahead and Backtracking: `attempt`, `look_ahead`, `not_followed_by`.
 - Grouping: `between`, `separated_by0`, `separated_by1`.
 - Associativity: `chain_left`, `chain_right`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ powerful features like arbitrary lookahead and nested parsers.
 Add YAPCoL to your `Cargo.toml`:
 ```toml
 [dependencies]
-yapcol = "0.8.0"
+yapcol = "0.8.1"
 ```
 
 Or use `cargo add`:

--- a/src/input/core.rs
+++ b/src/input/core.rs
@@ -247,9 +247,7 @@ where
 			if let Some(previous_frame) = self.look_ahead_frames.last_mut() {
 				previous_frame.add_count(frame.length())
 			} else {
-				let buffer_length = self.look_ahead_buffer.len();
-				self.look_ahead_buffer
-					.truncate(buffer_length - frame.length());
+				self.look_ahead_buffer.drain(0..frame.length());
 			}
 		}
 
@@ -420,17 +418,26 @@ mod tests {
 		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		assert_eq!(input.next_token().unwrap().token_owned(), '1');
 		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
+		assert_eq!(input.next_token().unwrap().token_owned(), '2');
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		let handler2 = input.start_look_ahead();
 		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
-		assert_eq!(input.next_token().unwrap().token_owned(), '2');
+		assert_eq!(input.next_token().unwrap().token_owned(), '3');
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
+		assert_eq!(input.next_token().unwrap().token_owned(), '4');
+		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
+		assert_eq!(input.next_token().unwrap().token_owned(), '5');
 		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
 		input.stop_look_ahead(handler2, true);
 		assert_eq!(input.next_location, TokenLocation::BufferTail);
-		assert_eq!(input.next_token().unwrap().token_owned(), '2');
-		assert_eq!(input.next_location, TokenLocation::StreamLookingAhead);
-		input.stop_look_ahead(handler1, false);
-		assert_eq!(input.next_location, TokenLocation::Stream);
 		assert_eq!(input.next_token().unwrap().token_owned(), '3');
+		assert_eq!(input.next_location, TokenLocation::BufferTail);
+		input.stop_look_ahead(handler1, false);
+		assert_eq!(input.next_location, TokenLocation::BufferHead);
+		assert_eq!(input.next_token().unwrap().token_owned(), '4');
+		assert_eq!(input.next_location, TokenLocation::BufferHead);
+		assert_eq!(input.next_token().unwrap().token_owned(), '5');
+		assert_eq!(input.next_location, TokenLocation::Stream);
 	}
 
 	#[test]


### PR DESCRIPTION
# Overview
This version fixes a bug on `input::core`'s lookahead feature.

## Bug Fixes
Fix `input::core::stop_look_ahead` truncating the lookahead buffer instead of draining, leaving consumed tokens on the lookahead buffer while removing unconsumed ones.

## Documentation
Fix missing combinator `once_or_more_until` on README.